### PR TITLE
Mryan ast debug

### DIFF
--- a/src/QAST/Children.nqp
+++ b/src/QAST/Children.nqp
@@ -18,12 +18,16 @@ role QAST::Children {
     }
 
     method dump_node_list(int $indent, @onto, @node_list) {
+        # Guide lines are triggered from here - if this is a Block
+        # node, then we request a guide line next to its children
+        my $guide-requested := nqp::istype(self, QAST::Block) ;
+
         for @node_list {
             if nqp::istype($_, QAST::Node) {
-                nqp::push(@onto, $_.dump($indent));
+                nqp::push(@onto, $_.dump($indent, :guide-line($guide-requested) ));
             }
             else {
-                nqp::push(@onto, self.dump_indent_string($indent));
+                nqp::push(@onto, self.dump_indent_string($indent, :guide-line($guide-requested) )) ;
                 nqp::push(@onto, '- ');
                 nqp::istype($_, NQPMu)
                     ?? nqp::push(@onto, '(NQPMu)')

--- a/src/QAST/Children.nqp
+++ b/src/QAST/Children.nqp
@@ -23,7 +23,7 @@ role QAST::Children {
                 nqp::push(@onto, $_.dump($indent));
             }
             else {
-                nqp::push(@onto, nqp::x(' ', $indent));
+                nqp::push(@onto, self.dump_indent_string($indent));
                 nqp::push(@onto, '- ');
                 nqp::istype($_, NQPMu)
                     ?? nqp::push(@onto, '(NQPMu)')
@@ -44,7 +44,7 @@ role QAST::Children {
         my $extra := 0;
         for self.extra_children -> $tag, $nodes {
             if $nodes {
-                nqp::push(@onto, nqp::x(' ', $indent));
+                nqp::push(@onto, self.dump_indent_string($indent));
                 nqp::push(@onto, "[" ~ $tag ~ "]");
                 nqp::push(@onto, "\n");
                 self.dump_node_list($indent+2, @onto, nqp::islist($nodes) ?? $nodes !! [$nodes]);
@@ -53,7 +53,7 @@ role QAST::Children {
         }
 
         if $extra && @!children {
-            nqp::push(@onto, nqp::x(' ', $indent) ~ "[children]\n");
+            nqp::push(@onto, self.dump_indent_string($indent) ~ "[children]\n");
             self.dump_node_list($indent+2, @onto, @!children);
         } else {
             self.dump_node_list($indent, @onto, @!children);

--- a/src/QAST/Node.nqp
+++ b/src/QAST/Node.nqp
@@ -131,9 +131,9 @@ class QAST::Node {
         nqp::die(self.HOW.name(self) ~ " does not support evaluating unquotes");
     }
 
-    method dump(int $indent = 0) {
+    method dump(int $indent = 0, :$guide-line = 0) {
         my @chunks := [
-            self.dump_indent_string($indent), '- ', self.HOW.name(self)
+            self.dump_indent_string($indent, :$guide-line), '- ', self.HOW.name(self)
         ];
         my $extra := self.dump_extra_node_info();
         if nqp::chars($extra) {
@@ -182,10 +182,12 @@ class QAST::Node {
     my $indent-string := "" ;
     my $indent-length := 0  ;
 
-    method dump_indent_string(int $ind) {
+    method dump_indent_string(int $ind, :$guide-line) {
         if $ind > $indent-length {
             my $diff := $ind - $indent-length ;
-            $indent-string := $indent-string ~ nqp::x(' ', $diff) ;
+            my $extra := $guide-line  ?? '│'   !! ' ';
+            $extra := $extra ~ nqp::x(' ', $diff-1) ;
+            $indent-string := $indent-string ~ $extra ;
             $indent-length := nqp::chars($indent-string)
         }
         elsif $ind < $indent-length {

--- a/src/QAST/Node.nqp
+++ b/src/QAST/Node.nqp
@@ -178,4 +178,21 @@ class QAST::Node {
     method dump_children(int $indent, @onto) { }
 
     method dump_extra_node_info() { '' }
+
+    my $indent-string := "" ;
+    my $indent-length := 0  ;
+
+    method dump_indent_string(int $ind) {
+        if $ind > $indent-length {
+            my $diff := $ind - $indent-length ;
+            $indent-string := $indent-string ~ nqp::x(' ', $diff) ;
+            $indent-length := nqp::chars($indent-string)
+        }
+        elsif $ind < $indent-length {
+            $indent-string := nqp::substr($indent-string, 0, $ind) ;
+            $indent-length := $ind
+        }
+
+        $indent-string
+    }
 }

--- a/src/QAST/Node.nqp
+++ b/src/QAST/Node.nqp
@@ -133,7 +133,7 @@ class QAST::Node {
 
     method dump(int $indent = 0) {
         my @chunks := [
-            nqp::x(' ', $indent), '- ', self.HOW.name(self),
+            self.dump_indent_string($indent), '- ', self.HOW.name(self)
         ];
         my $extra := self.dump_extra_node_info();
         if nqp::chars($extra) {

--- a/src/QAST/VM.nqp
+++ b/src/QAST/VM.nqp
@@ -19,7 +19,7 @@ class QAST::VM is QAST::Node does QAST::Children {
 
     method dump_children(int $indent, @onto) {
         for %!alternatives {
-            nqp::push(@onto, nqp::x(' ', $indent));
+            nqp::push(@onto, self.dump_indent_string($indent));
             nqp::push(@onto, '[');
             nqp::push(@onto, $_.key);
             nqp::push(@onto, "]\n");
@@ -28,7 +28,7 @@ class QAST::VM is QAST::Node does QAST::Children {
                 nqp::push(@onto, $_.value.dump($indent+2));
             }
             else {
-                nqp::push(@onto, nqp::x(' ', $indent+2));
+                nqp::push(@onto, self.dump_indent_string($indent+2));
                 nqp::push(@onto, '- ');
                 if $_.key eq 'loadlibs' {
                     nqp::push(@onto, nqp::join(' ',$_.value));


### PR DESCRIPTION
All changes are to code that dumps QAST nodes when the user specifies "--target=ast" to the command line.  There is no change to anything else.

The first two commits factor out the production of "indent strings" - series of spaces - to a single method in QAST::Node called dump_indent_string.  After these two commits, everything works exactly the same as before including when "--target=ast" is specified.

The third commit modifies the dump_indent_string method to take a named parameter,  :$guide-line  which produces, well, a guide line next to the children of nodes that are dumped with the argument set to a true value.  This is hard to explain, so I've posted a gist here: https://gist.github.com/mryan/e64e93362a275fa0b41cf6650c5d8e6c

You see the lines help with seeing the alignment of various nodes to see what's on the same level and what's not.  They also make very clear what's part of any given block.  Having said that, I recognise that this is a debatable improvement - which is why I've said all along " *may* be generally useful".  Please feel free to reject this outright and I'll simply put a patch on a blog somewhere for people to use it if they're interested.  Its just something I conjured up to make the QAST dumps a little easier to read.