### PR TITLE
Enable dynamic QAST Tree building

### DIFF
--- a/src/HLL/Actions.nqp
+++ b/src/HLL/Actions.nqp
@@ -134,8 +134,9 @@ class HLL::Actions {
         }
         if $key eq 'POSTFIX' {
             $ast.unshift($/[0].ast);
-        }
-        else {
+        } elsif nqp::isinvokable($ast) {
+            $ast := $ast($/.list);
+        } else {
             for $/.list { if nqp::defined($_.ast) { $ast.push($_.ast); } }
         }
         make $ast;


### PR DESCRIPTION
By using function, the developer can plug different types of QAST node in the AST. For example, upon invoking the function, it may return `QAST::Op.new(:op<callmethod>)` or `QAST::Var.new(:scope<attribute>)`, depending on the terms that was passed.