### PR TITLE
[IP6NS Grant] Implement support for bind before connect with sync sockets

### DIFF
--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2231,7 +2231,8 @@ QAST::OperationsJAST.map_classlib_core_op('spurtasync', $TYPE_OPS, 'spurtasync',
 
 QAST::OperationsJAST.map_classlib_core_op('socket', $TYPE_OPS, 'socket', [$RT_INT], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('connect', $TYPE_OPS, 'connect', [$RT_OBJ, $RT_STR, $RT_INT, $RT_INT], $RT_OBJ, :tc);
-QAST::OperationsJAST.map_classlib_core_op('bindsock', $TYPE_OPS, 'bindsock', [$RT_OBJ, $RT_STR, $RT_INT, $RT_INT, $RT_INT], $RT_OBJ, :tc);
+QAST::OperationsJAST.map_classlib_core_op('bindsock', $TYPE_OPS, 'bindsock', [$RT_OBJ, $RT_STR, $RT_INT, $RT_INT], $RT_OBJ, :tc);
+QAST::OperationsJAST.map_classlib_core_op('listen', $TYPE_OPS, 'listen', [$RT_OBJ, $RT_INT], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('accept', $TYPE_OPS, 'accept', [$RT_OBJ], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('getport', $TYPE_OPS, 'getport', [$RT_OBJ], $RT_INT, :tc);
 

--- a/src/vm/jvm/runtime/org/perl6/nqp/io/IIOBindable.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/io/IIOBindable.java
@@ -4,6 +4,6 @@ import org.perl6.nqp.runtime.ThreadContext;
 
 public interface IIOBindable {
 
-    public void bind(ThreadContext tc, String host, int port, int backlog);
+    public void bind(ThreadContext tc, String host, int port);
 
 }

--- a/src/vm/jvm/runtime/org/perl6/nqp/io/IIOListenable.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/io/IIOListenable.java
@@ -1,0 +1,9 @@
+package org.perl6.nqp.io;
+
+import org.perl6.nqp.runtime.ThreadContext;
+
+public interface IIOListenable {
+
+    public void listen(ThreadContext tc, int backlog);
+
+}

--- a/src/vm/jvm/runtime/org/perl6/nqp/io/SocketHandle.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/io/SocketHandle.java
@@ -8,7 +8,7 @@ import java.nio.charset.Charset;
 import org.perl6.nqp.runtime.ExceptionHandling;
 import org.perl6.nqp.runtime.ThreadContext;
 
-public class SocketHandle extends SyncHandle {
+public class SocketHandle extends SyncHandle implements IIOBindable {
 
     public SocketHandle(ThreadContext tc) {
         try {
@@ -22,6 +22,16 @@ public class SocketHandle extends SyncHandle {
     public SocketHandle(ThreadContext tc, SocketChannel existing) {
         chan = existing;
         setEncoding(tc, Charset.forName("UTF-8"));
+    }
+
+    @Override
+    public void bind(ThreadContext tc, String host, int port) {
+        try {
+            InetSocketAddress addr = new InetSocketAddress(host, port);
+            ((SocketChannel)chan).bind(addr);
+        } catch (IOException e) {
+            throw ExceptionHandling.dieInternal(tc, e);
+        }
     }
 
     public void connect(ThreadContext tc, String host, int port) {

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/IOOps.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/IOOps.java
@@ -197,7 +197,8 @@ public final class IOOps {
         AsyncServerSocketHandle handle = new AsyncServerSocketHandle(tc);
         task.handle = handle;
 
-        handle.bind(tc, host, (int) port, (int) backlog);
+        handle.bind(tc, host, (int) port);
+        handle.listen(tc, (int) backlog);
         handle.accept(tc, task);
 
         return task;

--- a/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/perl6/nqp/runtime/Ops.java
@@ -66,6 +66,7 @@ import org.perl6.nqp.io.IIOEncodable;
 import org.perl6.nqp.io.IIOExitable;
 import org.perl6.nqp.io.IIOInteractive;
 import org.perl6.nqp.io.IIOLineSeparable;
+import org.perl6.nqp.io.IIOListenable;
 import org.perl6.nqp.io.IIOLockable;
 import org.perl6.nqp.io.IIOSeekable;
 import org.perl6.nqp.io.IIOSyncReadable;
@@ -469,7 +470,7 @@ public final class Ops {
         return obj;
     }
 
-    public static SixModelObject bindsock(SixModelObject obj, String host, long port, long family, long backlog, ThreadContext tc) {
+    public static SixModelObject bindsock(SixModelObject obj, String host, long port, long family, ThreadContext tc) {
         IOHandleInstance h = (IOHandleInstance)obj;
 
 		switch ((int) family) {
@@ -477,7 +478,7 @@ public final class Ops {
 			case SOCKET_FAMILY_INET:
 			case SOCKET_FAMILY_INET6:
 				if (h.handle instanceof IIOBindable) {
-					((IIOBindable)h.handle).bind(tc, host, (int) port, (int) backlog);
+					((IIOBindable)h.handle).bind(tc, host, (int) port);
 				} else {
 					ExceptionHandling.dieInternal(tc,
 						"This handle does not support bind");
@@ -493,6 +494,17 @@ public final class Ops {
 				break;
 		}
 
+        return obj;
+    }
+
+    public static SixModelObject listen(SixModelObject obj, long backlog, ThreadContext tc) {
+        IOHandleInstance h = (IOHandleInstance)obj;
+        if (h.handle instanceof IIOListenable) {
+            ((IIOListenable)h.handle).listen(tc, (int) backlog);
+        } else {
+            ExceptionHandling.dieInternal(tc,
+                "This handle does not support listen");
+        }
         return obj;
     }
 

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -2302,6 +2302,7 @@ QAST::MASTOperations.add_core_moarop_mapping('filenofh', 'fileno_fh');
 QAST::MASTOperations.add_core_moarop_mapping('socket', 'socket');
 QAST::MASTOperations.add_core_moarop_mapping('connect', 'connect_sk', 0);
 QAST::MASTOperations.add_core_moarop_mapping('bindsock', 'bind_sk', 0);
+QAST::MASTOperations.add_core_moarop_mapping('listen', 'listen_sk', 0);
 QAST::MASTOperations.add_core_moarop_mapping('accept', 'accept_sk');
 QAST::MASTOperations.add_core_moarop_mapping('getport', 'getport_sk');
 QAST::MASTOperations.add_core_moarop_mapping('setbuffersizefh', 'setbuffersize_fh', 0);


### PR DESCRIPTION
This is needed for upcoming support for bind before connect and UDP sockets with `IO::Socket::INET`.

Passes `make test` and `make spectest`.

See https://github.com/MoarVM/MoarVM/pull/1231