### PR TITLE
Use NQP prefix for finding profiler template

### DIFF
--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -13,7 +13,7 @@ my sub literal_subst(str $source, str $pattern, $replacement) {
 
 class HLL::Backend::MoarVM {
     our %moar_config := nqp::backendconfig();
-    
+
     my sub read_ui32($fh, $buf?) {
         unless $buf { $buf := nqp::create($NQPBuf) }
         nqp::readfh($fh, $buf, 4);
@@ -691,7 +691,7 @@ class HLL::Backend::MoarVM {
         my str $template;
 
         if !$want_json && !$want_sql {
-            my $temppath := nqp::backendconfig()<prefix> ~ '/share/nqp/lib/profiler/template.html';
+            my $temppath := nqpconfig()<prefix> ~ '/share/nqp/lib/profiler/template.html';
             $template := try slurp('src/vm/moar/profiler/template.html');
             unless $template {
                 $template := try slurp($temppath);

--- a/tools/lib/NQP/Config/NQP.pm
+++ b/tools/lib/NQP/Config/NQP.pm
@@ -93,6 +93,14 @@ sub configure_misc {
 
     $config->{moar_stage0} = $self->nfp( "src/vm/moar/stage0", no_quote => 1 );
     $config->{jvm_stage0}  = $self->nfp( "src/vm/jvm/stage0",  no_quote => 1 );
+
+    # TODO: Use the template infrastructure from nqp-configure?
+    open my $configfile, '>', 'src/core/Config.nqp';
+    print $configfile "# This file is generated automatically by $0\n";
+    print $configfile "sub nqpconfig() {\n";
+    print $configfile "    nqp::hash('prefix', '$config->{prefix}');\n";
+    print $configfile "}\n";
+    close $configfile;
 }
 
 sub configure_moar_backend {

--- a/tools/templates/Makefile-common.in
+++ b/tools/templates/Makefile-common.in
@@ -12,6 +12,7 @@ COMMON_HLL_SOURCES = \
 HLL_COMBINED = NQPHLL.nqp
 
 CORE_SETTING_SOURCES = \
+  @nfp(src/core/Config.nqp)@ \
   @nfp(src/core/NativeTypes.nqp)@ \
   @nfp(src/core/NQPRoutine.nqp)@ \
   @nfp(src/core/NQPMu.nqp)@ \


### PR DESCRIPTION
Fixes #567.

This fixes the problem but I am not sure what would be the best way to generate the file with the nqpconfig subroutine definition in it.