### PR TITLE
Static nqp home hll var

### DIFF
--- a/tools/build/gen-version.pl
+++ b/tools/build/gen-version.pl
@@ -15,7 +15,7 @@ use File::Find;
 use POSIX 'strftime';
 
 my $prefix = shift // '';
-my $nqp_home = shift // '';
+my $static_nqp_home = shift // '';
 my $libdir = shift // '';
 
 open(my $fh, '<', 'VERSION') or die $!;
@@ -36,11 +36,12 @@ my $source_digest = $sha->hexdigest;
 
 print <<"END_VERSION";
 sub hll-config(\$config) {
-    \$config<version>       := '$VERSION';
-    \$config<prefix>        := '$prefix';
-    \$config<nqp_home>      := '$nqp_home';
-    \$config<libdir>        := '$libdir';
-    \$config<source-digest> := '$source_digest';
+    \$config<version>         := '$VERSION';
+    \$config<prefix>          := '$prefix';
+    \$config<static-nqp-home> := '$static_nqp_home';
+    \$config<nqp-home>        := '$static_nqp_home';
+    \$config<libdir>          := '$libdir';
+    \$config<source-digest>   := '$source_digest';
 }
 END_VERSION
 

--- a/tools/lib/NQP/Config/NQP.pm
+++ b/tools/lib/NQP/Config/NQP.pm
@@ -74,6 +74,8 @@ sub configure_refine_vars {
               || File::Spec->catdir( $config->{'prefix'}, 'share', 'nqp' )
         )
     );
+
+    $config->{static_nqp_home} = $config->{relocatable} eq 'reloc' ? '' : $config->{nqp_home};
 }
 
 sub configure_misc {
@@ -115,7 +117,7 @@ sub configure_moar_backend {
     }
     else {
         my $qchar = $config->{quote};
-        $imoar->{config}{static_nqp_home} = $config->{nqp_home};
+        $imoar->{config}{static_nqp_home} = $config->{static_nqp_home};
         $imoar->{config}{static_nqp_home_define} =
             '-DSTATIC_NQP_HOME='
           . $qchar

--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -117,7 +117,7 @@
 
 @nfp(@stage_dir@/@bsm(NQP)@)@: @prev_stage_dir@ @nfp(@stage_dir@/@bsm(QAST)@)@ @nfp(@stage_dir@/@bsm(P6QREGEX)@)@ @bpm(SOURCES)@
 	@echo(+++ Creating	stage @stage@ NQP)@
-	$(NOECHO)$(PERL5) @shquot(@script(gen-version.pl)@)@ @q($(PREFIX))@ @q($(NQP_HOME))@ @q($(NQP_LIB_DIR))@ > @nfpq(@stage_dir@/nqp-config.nqp)@
+	$(NOECHO)$(PERL5) @shquot(@script(gen-version.pl)@)@ @q($(PREFIX))@ @q($(STATIC_NQP_HOME))@ @q($(NQP_LIB_DIR))@ > @nfpq(@stage_dir@/nqp-config.nqp)@
 	$(NOECHO@nop())@@bpm(@ucstage@_GEN_CAT)@ @bpm(NQP_SOURCES)@ @nfpq(@stage_dir@/nqp-config.nqp)@ > @nfpq(@stage_dir@/$(NQP_COMBINED))@
 	$(NOECHO@nop())@@bpm(@ucprev_stage@_NQP)@ --module-path=@shquot(@stage_dir@)@ --setting-path=@shquot(@stage_dir@)@ \
 	    --setting=NQPCORE --target=@btarget@ --no-regex-lib @bpm(PRECOMP_@ucstage@_FLAGS)@ @bpm(NQP_@ucstage@_FLAGS)@ \

--- a/tools/templates/Makefile-common.in
+++ b/tools/templates/Makefile-common.in
@@ -123,9 +123,10 @@ SYSROOT         = @nfp(@sysroot@)@
 PREFIX          = @nfp(@prefix@)@
 BIN_DIR         = @nfp(@prefix@/bin)@
 NQP_HOME        = @nfp(@nqp_home@)@
+STATIC_NQP_HOME = @nfp(@static_nqp_home@)@
 NQP_LIB_DIR     = @nfp($(NQP_HOME)/lib)@
 PROVE_OPTIONS   = -j0$(TEST_JOBS)
 PROVE           = prove $(PROVE_OPTIONS)
-BASE_DIR		= @nfp(@base_dir@)@
+BASE_DIR        = @nfp(@base_dir@)@
 
 # vim: ft=make noexpandtab ts=4 sw=4

--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -74,8 +74,8 @@ THIRDPARTY_JARS = $(ASM)@cpsep@$(ASMTREE)@cpsep@$(JLINE)@cpsep@$(JNA)
 	@echo(+++ Preparing Java runtime)@
 	$(NOECHO)$(MKPATH) bin
 	$(NOECHO)$(JAVAC) --release 9 -cp @q($(THIRDPARTY_JARS))@ -g -d bin -encoding UTF8 $(RUNTIME_JAVAS)
-	$(NOECHO)$(PERL5) @shquot(@script(gen-jvm-properties.pl)@)@ . @nfpq($(NQP_HOME))@ @q($(THIRDPARTY_JARS))@ > jvmconfig.properties
-	$(NOECHO)$(PERL5) @shquot(@script(gen-jvm-properties.pl)@)@ @nfpq(@prefix@)@ @nfpq($(NQP_HOME))@ @q($(THIRDPARTY_JARS))@ > @nfpq(bin/jvmconfig.properties)@
+	$(NOECHO)$(PERL5) @shquot(@script(gen-jvm-properties.pl)@)@ . @nfpq($(STATIC_NQP_HOME))@ @q($(THIRDPARTY_JARS))@ > jvmconfig.properties
+	$(NOECHO)$(PERL5) @shquot(@script(gen-jvm-properties.pl)@)@ @nfpq(@prefix@)@ @nfpq($(STATIC_NQP_HOME))@ @q($(THIRDPARTY_JARS))@ > @nfpq(bin/jvmconfig.properties)@
 	$(NOECHO)$(JAR) cf0 @bsm(RUNTIME)@ -C @nfp(bin/)@ .
 
 @bpm(BUILD_RUNNER)@: @mkquot(@configure_script@)@ @@template(nqp-j)@@ @@template(runner-prelude)@@

--- a/tools/templates/jvm/Makefile.in
+++ b/tools/templates/jvm/Makefile.in
@@ -78,7 +78,7 @@ THIRDPARTY_JARS = $(ASM)@cpsep@$(ASMTREE)@cpsep@$(JLINE)@cpsep@$(JNA)
 	$(NOECHO)$(PERL5) @shquot(@script(gen-jvm-properties.pl)@)@ @nfpq(@prefix@)@ @nfpq($(STATIC_NQP_HOME))@ @q($(THIRDPARTY_JARS))@ > @nfpq(bin/jvmconfig.properties)@
 	$(NOECHO)$(JAR) cf0 @bsm(RUNTIME)@ -C @nfp(bin/)@ .
 
-@bpm(BUILD_RUNNER)@: @mkquot(@configure_script@)@ @@template(nqp-j)@@ @@template(runner-prelude)@@
+@bpm(BUILD_RUNNER)@: @mkquot(@configure_script@)@ @@template(nqp-j)@@ @@template(runner-prelude)@@ @bsm(NQP)@
 	@echo(+++ Setting up	$@)@
 	$(NOECHO)$(CP) @bpm(RUNNER_JARS)@ @q(@bpm(RUNNER_JAR_DIR)@)@
 	$(NOECHO)$(CP) @bpm(RUNNER_LIBS)@ @q(@bpm(RUNNER_LIB_DIR)@)@

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -70,14 +70,14 @@
 	@echo(+++ Compiling	$@)@
 	$(NOECHO)$(RM_F) $@
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
-	$(NOECHO)@bpm(CC_INST_NQP)@ @if(relocatable -DSTATIC_EXEC_PATH=@q(@c_escape(@nfp(@prefix@/bin/@bpm(NQP)@)@)@)@)@ @moar::ccout@inst-nqp@moar::obj@ @nfp(src/vm/moar/runner/main.c)@
+	$(NOECHO)@bpm(CC_INST_NQP)@ @if(relocatable==nonreloc -DSTATIC_EXEC_PATH=@q(@c_escape(@nfp(@prefix@/bin/@bpm(NQP)@)@)@)@)@ @moar::ccout@inst-nqp@moar::obj@ @nfp(src/vm/moar/runner/main.c)@
 	$(NOECHO)@bpm(LD_INST_NQP)@ @moar::ldout@$@ inst-nqp@moar::obj@ @bpm(LD_INST_NQP_POST)@
 
 @bpm(INST_NQP_M)@: @nfp(src/vm/moar/runner/main.c)@
 	@echo(+++ Compiling	$@)@
 	$(NOECHO)$(RM_F) $@
 # Using only the pkgconfig moar includes does not work, because moar.h assumes all the specific includes below.
-	$(NOECHO)@bpm(CC_INST_NQP)@ @if(relocatable -DSTATIC_EXEC_PATH=@q(@c_escape(@nfp(@prefix@/bin/@bpm(NQP_M)@)@)@)@)@ @moar::ccout@inst-nqp-m@moar::obj@ @nfp(src/vm/moar/runner/main.c)@
+	$(NOECHO)@bpm(CC_INST_NQP)@ @if(relocatable==nonreloc -DSTATIC_EXEC_PATH=@q(@c_escape(@nfp(@prefix@/bin/@bpm(NQP_M)@)@)@)@)@ @moar::ccout@inst-nqp-m@moar::obj@ @nfp(src/vm/moar/runner/main.c)@
 	$(NOECHO)@bpm(LD_INST_NQP)@ @moar::ldout@$@ inst-nqp-m@moar::obj@ @bpm(LD_INST_NQP_POST)@
 
 @bpm(BUILD_RUNNER)@: @@configure_script@@ @@template(@platform@/nqp-m-build.c)@@


### PR DESCRIPTION
This is a revert-revert. Problems should be ironed out this time.

Also be more explicit about whether the nqp_home variable references the
folder (where we install to): nqp_home
or the static compile time override to set a different home dir:
static_nqp_home
The above is a requirement for an upcoming rakudo PR that fixes the --nqp-home Configure.pl option.

Also fix relocatability for the nqp executable.