### PR TITLE
Remove qlist opcode

### DIFF
--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -695,9 +695,6 @@ QAST::OperationsJAST.add_core_op('intify', -> $qastcomp, $op {
 QAST::OperationsJAST.add_core_op('numify', -> $qastcomp, $op {
     $qastcomp.as_jast($op[0], :want($RT_NUM))
 });
-QAST::OperationsJAST.add_core_op('qlist', -> $qastcomp, $op {
-    $qastcomp.as_jast(QAST::Op.new( :op('list'), |@($op) ))
-});
 QAST::OperationsJAST.add_core_op('hash', -> $qastcomp, $op {
     # Just desugar to create the empty hash.
     my $hash := $qastcomp.as_jast(QAST::Op.new(

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -618,9 +618,6 @@ QAST::MASTOperations.add_core_op('numify', -> $qastcomp, $op {
 QAST::MASTOperations.add_core_op('intify', -> $qastcomp, $op {
     $qastcomp.as_mast($op[0], :want($MVM_reg_int64))
 });
-QAST::MASTOperations.add_core_op('qlist', -> $qastcomp, $op {
-    $qastcomp.as_mast(QAST::Op.new( :op('list'), |@($op) ))
-});
 QAST::MASTOperations.add_core_op('hash', -> $qastcomp, $op {
     # Just desugar to create the empty hash.
     my $regalloc := $*REGALLOC;


### PR DESCRIPTION
Passes 'make m-test' and 'make j-test' - this wasn't tested in rakudo, but rakudo does not refer to this opcode.