### PR TITLE
Enable running precompiled scripts

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -411,8 +411,8 @@ class HLL::Compiler does HLL::Backend::Default {
         $!user_progname := join(',', @files);
         my @codes;
         for @files -> $filename {
-        my $err := 0;
-        my $in-handle;
+            my $err := 0;
+            my $in-handle;
             try {
                 if $filename eq '-' {
                     $in-handle := stdin();

--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -434,7 +434,6 @@ class HLL::Compiler does HLL::Backend::Default {
                 }
             }
             nqp::exit(1) if $err;
-            #nqp::exit(0) if nqp::defined(%adverbs<bytecode>);
             try {
                 nqp::push(@codes, $in-handle.slurp());
                 unless $filename eq '-' {


### PR DESCRIPTION
This change is part of the GSoC of @pamplemoussecache but is useful on its own.
With this change it is possible to run a precompiled script:
```
raku --target=mbc --output=script.mbc script.raku
raku -b script.mbc
```
It is possible there limits to this functionality that are currently unexplored, but I think we should get this change merged anyways.