### PR TITLE
Don't bind an int attribute to 0 directly after construction

### DIFF
--- a/src/QAST/BVal.nqp
+++ b/src/QAST/BVal.nqp
@@ -3,7 +3,6 @@ class QAST::BVal is QAST::Node {
 
     method new(:$value, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::BVal, '$!value', $value);
         $node.set(%options) if %options;
         $node

--- a/src/QAST/Block.nqp
+++ b/src/QAST/Block.nqp
@@ -13,7 +13,6 @@ class QAST::Block is QAST::Node does QAST::Children {
 
     method new(str :$name, str :$blocktype, *@children, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::Block, '@!children', @children);
         nqp::bindattr_s($node, QAST::Block, '$!name', $name);
         nqp::bindattr_s($node, QAST::Block, '$!blocktype', $blocktype);

--- a/src/QAST/CompUnit.nqp
+++ b/src/QAST/CompUnit.nqp
@@ -33,7 +33,6 @@ class QAST::CompUnit is QAST::Node does QAST::Children {
 
     method new(*@children, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::CompUnit, '@!children', @children);
         $node.set(%options) if %options;
         $node

--- a/src/QAST/IVal.nqp
+++ b/src/QAST/IVal.nqp
@@ -3,7 +3,6 @@ class QAST::IVal is QAST::Node {
 
     method new(int :$value, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr_i($node, QAST::IVal, '$!value', $value);
         nqp::bindattr($node, QAST::Node, '$!returns', int);
         $node.set(%options) if %options;

--- a/src/QAST/InlinePlaceholder.nqp
+++ b/src/QAST/InlinePlaceholder.nqp
@@ -5,7 +5,6 @@ class QAST::InlinePlaceholder is QAST::Node {
 
     method new(:$position, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr_i($node, QAST::InlinePlaceholder, '$!position', $position);
         $node.set(%options) if %options;
         $node

--- a/src/QAST/NVal.nqp
+++ b/src/QAST/NVal.nqp
@@ -3,7 +3,6 @@ class QAST::NVal is QAST::Node {
 
     method new(num :$value, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr_n($node, QAST::NVal, '$!value', $value);
         nqp::bindattr($node, QAST::Node, '$!returns', num);
         $node.set(%options) if %options;

--- a/src/QAST/NodeList.nqp
+++ b/src/QAST/NodeList.nqp
@@ -1,7 +1,6 @@
 class QAST::NodeList is QAST::Node does QAST::Children {
     method new(*@children, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::NodeList, '@!children', @children);
         $node.set(%options) if %options;
         $node

--- a/src/QAST/Op.nqp
+++ b/src/QAST/Op.nqp
@@ -6,7 +6,6 @@ class QAST::Op is QAST::Node does QAST::Children {
 
     method new(str :$name, str :$op, *@children, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::Op, '@!children', @children);
         nqp::bindattr_s($node, QAST::Op, '$!name', $name);
         nqp::bindattr_s($node, QAST::Op, '$!op', $op);

--- a/src/QAST/ParamTypeCheck.nqp
+++ b/src/QAST/ParamTypeCheck.nqp
@@ -1,7 +1,6 @@
 class QAST::ParamTypeCheck is QAST::Node does QAST::Children {
     method new(*@children, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::ParamTypeCheck, '@!children', @children);
         $node.set(%options) if %options;
         $node

--- a/src/QAST/Regex.nqp
+++ b/src/QAST/Regex.nqp
@@ -23,7 +23,6 @@ class QAST::Regex is QAST::Node does QAST::Children {
 
     method new(str :$rxtype, str :$subtype, *@children, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::Regex, '@!children', @children);
         nqp::bindattr_s($node, QAST::Regex, '$!rxtype', $rxtype);
         nqp::bindattr_s($node, QAST::Regex, '$!subtype', $subtype);

--- a/src/QAST/SVal.nqp
+++ b/src/QAST/SVal.nqp
@@ -3,7 +3,6 @@ class QAST::SVal is QAST::Node {
 
     method new(:$value, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr_s($node, QAST::SVal, '$!value', $value);
         nqp::bindattr($node, QAST::Node, '$!returns', str);
         $node.set(%options) if %options;

--- a/src/QAST/Stmt.nqp
+++ b/src/QAST/Stmt.nqp
@@ -3,7 +3,6 @@ class QAST::Stmt is QAST::Node does QAST::Children {
 
     method new(*@children, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::Stmt, '@!children', @children);
         $node.set(%options) if %options;
         $node

--- a/src/QAST/Stmts.nqp
+++ b/src/QAST/Stmts.nqp
@@ -3,7 +3,6 @@ class QAST::Stmts is QAST::Node does QAST::Children {
 
     method new(*@children, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::Stmts, '@!children', @children);
         $node.set(%options) if %options;
         $node

--- a/src/QAST/Unquote.nqp
+++ b/src/QAST/Unquote.nqp
@@ -3,7 +3,6 @@ class QAST::Unquote is QAST::Node {
 
     method new(int :$position, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr_i($node, QAST::Unquote, '$!position', $position);
         $node.set(%options) if %options;
         $node

--- a/src/QAST/VM.nqp
+++ b/src/QAST/VM.nqp
@@ -3,7 +3,6 @@ class QAST::VM is QAST::Node does QAST::Children {
 
     method new(*@children, *%alternatives) {
         my $obj := nqp::create(self);
-        nqp::bindattr_i($obj, QAST::Node, '$!flags', 0);
         nqp::bindattr($obj, QAST::VM, '@!children', @children);
         nqp::bindattr($obj, QAST::VM, '%!alternatives', %alternatives);
         $obj

--- a/src/QAST/Var.nqp
+++ b/src/QAST/Var.nqp
@@ -7,7 +7,6 @@ class QAST::Var is QAST::Node does QAST::Children {
 
     method new(:$name, str :$scope, str :$decl, *@children, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::Var, '@!children', @children);
         nqp::bindattr_s($node, QAST::Var, '$!name', $name);
         nqp::bindattr_s($node, QAST::Var, '$!scope', $scope);

--- a/src/QAST/WVal.nqp
+++ b/src/QAST/WVal.nqp
@@ -1,7 +1,6 @@
 class QAST::WVal is QAST::Node does QAST::CompileTimeValue {
     method new(:$value, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::WVal, '$!compile_time_value', $value);
         $node.set(%options) if %options;
         $node

--- a/src/QAST/Want.nqp
+++ b/src/QAST/Want.nqp
@@ -1,7 +1,6 @@
 class QAST::Want is QAST::Node does QAST::Children {
     method new(*@children, *%options) {
         my $node := nqp::create(self);
-        nqp::bindattr_i($node, QAST::Node, '$!flags', 0);
         nqp::bindattr($node, QAST::Want, '@!children', @children);
         $node.set(%options) if %options;
         $node


### PR DESCRIPTION
since we construct objects null-initialized anyway.

the QASTNodes.moarvm file shrinks by 544 bytes (about 0.54%). Even though it's a tiny change in total, we don't have to be wasteful either.