### PR TITLE
Fix t/nqp/114-pod-panic with a relocated `nqp` executable

### DIFF
--- a/t/nqp/114-pod-panic.t
+++ b/t/nqp/114-pod-panic.t
@@ -12,31 +12,38 @@ my $fh    := open($fname, :w);
 $fh.print($pod);
 close($fh);
 
-# ensure we use the correct executable
 my $cmd;
-if ((nqp::stat('./nqp-m', nqp::const::STAT_EXISTS) == 0)
-    && (nqp::stat('./nqp-j', nqp::const::STAT_EXISTS) == 0)) {
-    $cmd := './nqp';
-} else {
-    $cmd := nqp::getcomp('nqp').backend.name eq 'jvm' ?? './nqp-j' !! './nqp-m';
-}
-
-my $cmdargs := $fname;
-my $args := nqp::list($cmd, $cmdargs);
-
-# expected first line output to stderr:
-#   Obsolete pod format ... , please use =begin/=end instead at line 4, near "\n"
-my $regex := /^ \h* Obsolete \h+ pod \h+ format \h+ .+ ',' \h+ please \h+ use \h+ '=begin/=end' \h+ instead \h+ /;
-
-# running with only stderr capture"
-my @arr := run-command($args, :stderr);
-my $err := @arr[2];
-
+my $comp := nqp::getcomp("nqp");
 if nqp::getcomp('nqp').backend.name eq 'jvm' {
-    skip('local tests good, failing on travis-ci on the jvm', 1);
+    skip('neither nqp::execname() nor perl6.execname are available on NQP', 1);
+    #try {
+    #    $comp.eval("nqp::die(nqp::jvmgetproperties()<perl6.execname>)");
+    #    CATCH { $cmd := ~$_ }
+    #}
 }
 else {
-    ok($err ~~ $regex, 'got the correct output from stderr');
+    try {
+        $comp.eval("nqp::die(nqp::execname())");
+        CATCH { $cmd := ~$_ }
+    }
+
+    my $cmdargs := $fname;
+    my $args := nqp::list($cmd, $cmdargs);
+
+    # expected first line output to stderr:
+    #   Obsolete pod format ... , please use =begin/=end instead at line 4, near "\n"
+    my $regex := /^ \h* Obsolete \h+ pod \h+ format \h+ .+ ',' \h+ please \h+ use \h+ '=begin/=end' \h+ instead \h+ /;
+
+    # running with only stderr capture"
+    my @arr := run-command($args, :stderr);
+    my $err := @arr[2];
+
+    if nqp::getcomp('nqp').backend.name eq 'jvm' {
+        skip('local tests good, failing on travis-ci on the jvm', 1);
+    }
+    else {
+        ok($err ~~ $regex, 'got the correct output from stderr');
+    }
 }
 
 nqp::unlink($fname);


### PR DESCRIPTION
This change fixes t/nqp/114-pod-panic with a relocated `nqp` executable. There was some custom logic to determine the executable name to test with. I'm unsure if there was a deeper reason for the previous more complex logic. Let's see what CI has to say.