### PR TITLE
Perl6 to raku + fix links

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "3rdparty/nqp-configure"]
 	path = 3rdparty/nqp-configure
-	url = https://github.com/perl6/nqp-configure.git
+	url = https://github.com/Raku/nqp-configure.git

--- a/README.pod
+++ b/README.pod
@@ -105,7 +105,7 @@ scratch.
 
 =head2 JavaScript backend
 
-The best thing before playing with it/hacking on it is to contact pmurias via IRC at C<#raku> on *irc.freenode.org*.
+The best thing before playing with it/hacking on it is to contact pmurias via IRC at C<#raku> on L<irc.freenode.org|https://webchat.freenode.net/?channels=#raku>.
 We depend on C<node.js> at least 10.10.0
 
 Building the JavaScript backend currently requires building the moar backend:

--- a/README.pod
+++ b/README.pod
@@ -105,7 +105,7 @@ scratch.
 
 =head2 JavaScript backend
 
-The best thing before playing with it/hacking on it is to contact pmurias via IRC at #raku on irc.freenode.org.
+The best thing before playing with it/hacking on it is to contact pmurias via IRC at C<#raku> on *irc.freenode.org*.
 We depend on C<node.js> at least 10.10.0
 
 Building the JavaScript backend currently requires building the moar backend:
@@ -117,7 +117,7 @@ Currently it needs to be run like:
 
     $ ./nqp-js file.nqp
 
-If you are developing C<nqp-js>, you may want to pass the --link option to configure to have the nqp-runtime linked instead of installed
+If you are developing C<nqp-js>, you may want to pass the C<--link> option to configure to have the C<nqp-runtime> linked instead of installed
 
     $ cd src/vm/js/nqp-runtime; npm link .
     $ perl Configure --backends=moar,js

--- a/README.pod
+++ b/README.pod
@@ -7,7 +7,7 @@ for licensing details.
 
 This is "Not Quite Perl" -- a lightweight Raku-like environment for
 virtual machines.  The key feature of NQP is that it's designed to be a very
-small environment (as compared with, say, perl6 or Rakudo) and is focused on
+small environment (as compared with, say, raku or Rakudo) and is focused on
 being a high-level way to create compilers and libraries for virtual
 machines like MoarVM [1], the JVM, and others.
 
@@ -19,23 +19,23 @@ and regular expression engine for the virtual machine.
 
 =head2 Building from source
 
-=for HTML <a href="https://travis-ci.org/perl6/nqp"><img src="https://travis-ci.org/perl6/nqp.svg?branch=master"></a>
+=for HTML <a href="https://travis-ci.org/raku/nqp"><img src="https://travis-ci.org/raku/nqp.svg?branch=master"></a>
 
-To build NQP from source, you'll just need a C<make> utility and Perl 5.8 or
+To build NQP from source, you'll just need a C<make> utility and C<Perl> 5.8 or
 newer.  To automatically obtain and build MoarVM you may also need
-a git client.
+a C<git> client.
 
-To obtain NQP directly from its repository:
+To obtain C<NQP> directly from its repository:
 
-    $ git clone git://github.com/perl6/nqp.git
+    $ git clone git://github.com/Raku/nqp.git
 
 If you don't have git installed, you can get a tarball or zip of NQP from
-github by visiting http://github.com/perl6/nqp/tree/master and clicking
+github by visiting http://github.com/Raku/nqp/tree/master and clicking
 "Download".  Then unpack the tarball or zip.
 
-NQP can run on three different backends: MoarVM, the JVM, and JavaScript.
-The JVM and JavaScript backends are currently experimental.  The JVM backend
-requires JDK 1.9 (also known as JDK 9) or higher.
+C<NQP> can run on three different backends: C<MoarVM>, the C<JVM>, and C<JavaScript>.
+The C<JVM> and C<JavaScript> backends are currently experimental.  The JVM backend
+requires C<JDK 1.9> (also known as C<JDK 9>) or higher.
 
 Decide on which backends you want it to run, and configure and build it as
 follows:
@@ -47,9 +47,9 @@ Once you have a copy of NQP, build it as follows:
     $ make
 
 If you don't have an installed MoarVM, you can have
-Configure.pl build one for you by passing the C<--gen-moar> option to it as well.
+C<Configure.pl> build one for you by passing the C<--gen-moar> option to it as well.
 
-The C<make> step will create a "nqp" or "nqp.exe" executable in the current
+The C<make> step will create a C<nqp> or C<nqp.exe> executable in the current
 directory.  Programs can then be run from the build directory using a
 command like:
 
@@ -62,11 +62,11 @@ Configure.pl.
 Once built, NQP's C<make install> target will install NQP and its libraries
 into the same location as the MoarVM installation
 that was used to create it.  Until this step is
-performed, the "nqp" executable created by C<make> above can only be
+performed, the C<nqp> executable created by C<make> above can only be
 reliably run from the root of NQP's build directory.  After C<make install>
 is performed the executable can be run from any directory.
 
-If the NQP compiler is invoked without an explicit script to run, it enters
+If the C<NQP> compiler is invoked without an explicit script to run, it enters
 a small interactive mode that allows statements to be executed from the
 command line.  Each line entered is treated as a separate compilation unit,
 however (which means that subroutines are preserved after they are defined,
@@ -105,8 +105,8 @@ scratch.
 
 =head2 JavaScript backend
 
-The best thing before playing with it/hacking on it is to contact pmurias via IRC at #perl6 on irc.freenode.org.
-We depend on node.js at least 10.10.0
+The best thing before playing with it/hacking on it is to contact pmurias via IRC at #raku on irc.freenode.org.
+We depend on C<node.js> at least 10.10.0
 
 Building the JavaScript backend currently requires building the moar backend:
 
@@ -117,7 +117,7 @@ Currently it needs to be run like:
 
     $ ./nqp-js file.nqp
 
-If you are developing nqp-js, you may want to pass the --link option to configure to have the nqp-runtime linked instead of installed
+If you are developing C<nqp-js>, you may want to pass the --link option to configure to have the nqp-runtime linked instead of installed
 
     $ cd src/vm/js/nqp-runtime; npm link .
     $ perl Configure --backends=moar,js

--- a/docs/6model/faq.markdown
+++ b/docs/6model/faq.markdown
@@ -16,7 +16,7 @@ you've still yet to "waste" a kilobyte.
 When you pair a meta-class and a representation together, an s-table
 is created along with a type object. The type-object becomes your
 "handle" to that pairing, and can be used to create instances of
-the object. In some languages (Perl 6), you would also install the
+the object. In some languages (Raku), you would also install the
 type object into the namespace (package or lexpad), as the user's
 view of the type. However, that is not at all needed.
 

--- a/docs/6model/overview.markdown
+++ b/docs/6model/overview.markdown
@@ -19,7 +19,7 @@ workflow.
 
 1. Identify the kinds of object oriented types your language
    has and that you will need to implement. For example, in
-   Perl 6 we have - amongst other things - classes, roles and
+   Raku we have - amongst other things - classes, roles and
    enumerations. In Java, you'd have classes and interfaces.
    In JavaScript, you have prototype objects.
 
@@ -95,7 +95,7 @@ however. The following operations are available on representations.
   attributes are not keyed just one name) and an index for when it's
   possible to access an attribute by an offset rather than just by name.
   What's needed varies by representation.
-  
+
 * **bind_attribute** and its native friends are basically what you'd
   expect, and look largely like get_attribute apart from they take
   something to store in the attribute rather than doing a lookup.
@@ -128,21 +128,21 @@ following.
 
     class SimpleMetaObject {
         has %!methods;
-        
+
         method new_type() {
             my $meta-object := self.new();
             return nqp::newtype($meta-object, 'HashAttrStore');
         }
-        
+
         method add_method($type, $name, $code) {
             %!methods{$name} := $code;
         }
-        
+
         method find_method($type, $name) {
             %!methods{$name}
         }
     }
-    
+
 Notice how this meta-object is just written as a normal class. Of
 course, the class itself has a meta-object saying how it works - it's
 meta-objects all the way down. The next thing to note is that we just
@@ -164,7 +164,7 @@ The .HOW macro in NQP maps to the gethow opcode and it is used to
 get hold of the meta-object. We just pass a simple lambda expression in
 to add_method in order to specify what happens when the method is called.
 Finally, we can make an instance and call the method.
-    
+
     # Make an instance.
     my $obj := nqp::create($type);
 

--- a/docs/6model/repr-compose-protocol.markdown
+++ b/docs/6model/repr-compose-protocol.markdown
@@ -44,10 +44,10 @@ It may optionally have these keys:
   key since it just gets a reference to another object. It's native types or
   other compact things that can be flattened into the object body that are
   interesting.
-  
+
 * box_target - if this key is present, then this type is a target for boxing
   or unboxing.
-  
+
 * auto_viv_container - if this key is present then an access to an attribute
   that is uninitialized will cause that attribute to be set to a clone of the
   value under this key. If the value is a type object, the clone will not take
@@ -58,7 +58,7 @@ It may optionally have these keys:
   used with the object. This is primarily to support languages that need to
   reasonably efficiently provide positional things that can also be mixed
   in to in arbitrary ways.
-  
+
 * associative_delegate - the same as positional_delegate, for the associative
   part of the REPR API.
 
@@ -100,7 +100,7 @@ A hash that may have the following keys:
 * keytype - the type of the hash key. REPRs are likely to be restrictive here,
   since they need to understand the representation of the provided key well
   enough to hash it. This will probably mean strings and whatever REPR ObjAt
-  in Perl 6 (or some other language's variant) has.
+  in Raku (or some other language's variant) has.
 
 ## nativeref
 

--- a/docs/continuations.pod
+++ b/docs/continuations.pod
@@ -111,7 +111,7 @@ Complete examples may be found in t/jvm/01-continuations.t in the source distrib
 
 =head2 Lazy recursive reinstate optimization
 
-Consider the following (Perl 6):
+Consider the following (Raku):
 
     my $N = 10000;
 

--- a/docs/jvminterop-goals.pod
+++ b/docs/jvminterop-goals.pod
@@ -1,4 +1,4 @@
-Raku=encoding utf8
+=encoding utf8
 
 =head1 Introduction
 

--- a/docs/jvminterop-goals.pod
+++ b/docs/jvminterop-goals.pod
@@ -1,10 +1,10 @@
-=encoding utf8
+Raku=encoding utf8
 
 =head1 Introduction
 
 This infodump describes aspects of the most desirable interface for Java
 interop functionality in Rakudo, based on experience with CLR interop
-functionality in Niecza.  No aspects of implementation I<per se> are discussed. 
+functionality in Niecza.  No aspects of implementation I<per se> are discussed.
 
 =head1 Unsolved questions
 
@@ -26,10 +26,10 @@ objects that handle get and set.  (This works well in Niecza).
 Methods, including C<new> aka C<< <init> >>, should be bundled by short name
 and then turned into overload-resolving sets.  This can be done either by
 creating a composite method that implements Java overload rules, or by building
-a Perl 6 multi-dispatcher that wraps a set of methods.  Using a
+a Raku multi-dispatcher that wraps a set of methods.  Using a
 multi-dispatcher would probably require covariant wrappers.
 
-Java objects should be made to implement core Perl 6 roles whenever reasonable.
+Java objects should be made to implement core Raku roles whenever reasonable.
 C<MethodHandle>s and single-method interfaces (including the new single-method
 interfaces being added to Java 1.8 for use with lambdas) should function as
 Callable with a C<< postcircumfix:<( )> >>.  Arrays and objects assignable to
@@ -40,10 +40,10 @@ C<java.util.Iterable> things should probably be iterable, somehow.
 It may additionally be useful to provide semantics for C<java.util.Collection>
 and C<java.util.Set>, but that's I<probably> overkill.
 
-It shall be possible to throw and catch Java exceptions as Perl 6 exceptions.
+It shall be possible to throw and catch Java exceptions as Raku exceptions.
 (The current implementation is limited such that you can throw OR catch Java
 exceptions - a thrown Java exception is treated as a direct control operator to
-the innermost callback, and cannot be caught by Perl 6 exception handlers until
+the innermost callback, and cannot be caught by Raku exception handlers until
 it propagates to a callout point.)
 
 Since a C<java.lang.ClassLoader> is effectively the root of a class namespace,
@@ -58,14 +58,14 @@ some kind of C<Uninstantiatable> thing.
 Most objects should box as C<JavaObject>s.  In order for the interface to be
 most generally usable, it must be possible to get the exact same Java object
 out of the box - boxings that lose object identity are probably unacceptable.
-Primitive types have no such restriction and should be translated into Perl 6
+Primitive types have no such restriction and should be translated into Raku
 types freely.  C<BootJavaObject> already translates all primitives that
 correspond to 6model types in the obvious way, additionally C<char> is returned
 as a one-character C<str> and C<boolean> is mapped to an C<int> of 0 or 1.  The
-former is probably correct for Perl 6, but the latter should be overridden to
+former is probably correct for Raku, but the latter should be overridden to
 be C<True> or C<False>.
 
-It is acceptable to map reference types in cases where the Perl 6 object wraps
+It is acceptable to map reference types in cases where the Raku object wraps
 the corresponding type, so it can be recovered identically from the box.  This
 is the case for C<java.lang.String> / C<Str> and C<java.math.BigInteger> /
 C<Int>, and of course C<SixModelObject>.
@@ -84,15 +84,15 @@ an interpretation of "current".  Alternatively mechanisms can be provided in
 the library for retrieving the current context objects.
 
 Wherever an Iterator or Iterable is needed, it shall be acceptable to pass an
-iterable Perl 6 object; a wrapper Iterable shall be constructed which iterates
-the underlying Perl 6 object.
+iterable Raku object; a wrapper Iterable shall be constructed which iterates
+the underlying Raku object.
 
-Wherever a List is needed, it shall be acceptable to pass any Perl 6 object
+Wherever a List is needed, it shall be acceptable to pass any Raku object
 that does Positional.  Note that implementing the List interface faithfully
 requires C<splice> and C<elems> in addition to C<at_pos>, while C<exists> and
 C<delete> are not used.
 
-Wherever a Map is needed, it shall be acceptable to pass any Perl 6 object that
+Wherever a Map is needed, it shall be acceptable to pass any Raku object that
 does Associative.
 
 Wherever any non-collection interface type is needed, it shall be acceptable to

--- a/docs/release_guide.pod
+++ b/docs/release_guide.pod
@@ -77,13 +77,11 @@ Sign the tarball:
 
 =item 8
 
-Upload the release tarball and signature to L<http://rakudo.org/downloads/nqp>
-and L<https://rakudo.perl6.org/downloads/nqp/>:
+Upload the release tarball and signature to L<http://rakudo.org/downloads/nqp>:
 
   scp nqp-2013.12.tar.gz nqp-2013.12.tar.gz.asc \
         rakudo@rakudo.org:public_html/downloads/nqp/
-  scp nqp-2013.12.tar.gz nqp-2013.12.tar.gz.asc \
-        rakudo@www.p6c.org:public_html/downloads/nqp/
+  
 
 If you do not have permissions for that, ask one of (pmichaud, jnthn, FROGGS,
 masak, tadzik, moritz, PerlJam/perlpilot, [Coke], lizmat, timotimo, fsergot,

--- a/examples/hello_world.nqp
+++ b/examples/hello_world.nqp
@@ -1,3 +1,3 @@
 #!nqp
 
-say("Hello, awesome Not Quite Perl 6 World!");
+say("Hello, awesome Not Quite Perl World!");

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "nqp-js-cross-compiling",
   "bugs": {
-    "url:": "https://github.com/perl6/nqp/issues",
+    "url:": "https://github.com/Raku/nqp/issues",
     "email": "pawelmurias@gmail.com"
   },
   "license": "Artistic-2.0",
   "private": true,
-  "repository": "http://github.com/perl6/nqp/",
+  "repository": "http://github.com/Raku/nqp/",
   "devDependencies": {
     "eslint": "^5.16.0",
     "eslint-config-google": "^0.8.0"

--- a/src/how/NQPClassHOW.nqp
+++ b/src/how/NQPClassHOW.nqp
@@ -1,5 +1,5 @@
 # This is a first cut at a ClassHOW for NQP. It doesn't support all the stuff
-# that Perl 6 needs, but it's sufficient for NQP. Supports methods, attributes,
+# that Raku needs, but it's sufficient for NQP. Supports methods, attributes,
 # role composition, inheritance (single and multiple) and introspection.
 
 knowhow NQPClassHOW {


### PR DESCRIPTION
+ Perl6 to raku
+ fix the link for travis-ci
+ format README.pod
+ change Perl6 references to Raku in docs
+ remove redundant link https://rakudo.perl6.org/downloads/nqp/: in release_guide.pod
+ reflect correct repository of NQP to http://github.com/Raku/nqp/
+ add link to irc channel making it easy to go to the channel