### PR TITLE
Fix retrieving template.html location

### DIFF
--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -699,7 +699,7 @@ class HLL::Backend::MoarVM {
         my str $template;
 
         if !$want_json && !$want_sql {
-            my $temppath := nqp::backendconfig()<prefix> ~ '/share/nqp/lib/profiler/template.html';
+            my $temppath := nqp::getcomp('nqp').nqp-home() ~ '/lib/profiler/template.html';
             $template := try slurp('src/vm/moar/profiler/template.html');
             unless $template {
                 $template := try slurp($temppath);

--- a/tools/templates/jvm/nqp-j.in
+++ b/tools/templates/jvm/nqp-j.in
@@ -1,10 +1,35 @@
 @shebang@
 
-@if(platform==windows
-@setenv(JAR_DIR)@@jar_dir@
-@setenv(LIB_DIR)@@lib_dir@)@
-@if(platform!=windows
-@setenv(JAR_DIR)@@q(@jar_dir@)@
-@setenv(LIB_DIR)@@q(@lib_dir@)@)@
+# Sourced from https://stackoverflow.com/a/29835459/1975049
+rreadlink() (
+  target=$1 fname= targetDir= CDPATH=
+  { \unalias command; \unset -f command; } >/dev/null 2>&1
+  [ -n "$ZSH_VERSION" ] && options[POSIX_BUILTINS]=on
+  while :; do
+      [ -L "$target" ] || [ -e "$target" ] || { command printf '%s\n' "ERROR: '$target' does not exist." >&2; return 1; }
+      command cd "$(command dirname -- "$target")"
+      fname=$(command basename -- "$target")
+      [ "$fname" = '/' ] && fname=''
+      if [ -L "$fname" ]; then
+        target=$(command ls -l "$fname")
+        target=${target#* -> }
+        continue
+      fi
+      break
+  done
+  targetDir=$(command pwd -P)
+  if [ "$fname" = '.' ]; then
+    command printf '%s\n' "${targetDir%/}"
+  elif  [ "$fname" = '..' ]; then
+    command printf '%s\n' "$(command dirname -- "${targetDir}")"
+  else
+    command printf '%s\n' "${targetDir%/}/$fname"
+  fi
+)
 
-@exec(java)@ -Xss1m -Xmx1324m -Xbootclasspath/a:"@cur_dir@@envvar(LIB_DIR)@@cpsep@@nfp(@envvar(JAR_DIR)@/nqp-runtime.jar)@@cpsep@@nfp(@envvar(JAR_DIR)@/@asmfile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jlinefile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jnafile@)@@cpsep@@nfp(@envvar(LIB_DIR)@/nqp.jar)@" -cp "@cur_dir@@envvar(LIB_DIR)@" nqp @sh_allparams@
+EXEC=$(rreadlink "$0")
+DIR=$(dirname -- "$EXEC")
+@setenv(JAR_DIR)@@q(@jar_dir@)@
+@setenv(LIB_DIR)@@q(@lib_dir@)@
+
+@exec(java)@ -Dnqp.execname="$EXEC" -Xss1m -Xmx1324m -Xbootclasspath/a:"@cur_dir@@envvar(LIB_DIR)@@cpsep@@nfp(@envvar(JAR_DIR)@/nqp-runtime.jar)@@cpsep@@nfp(@envvar(JAR_DIR)@/@asmfile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jlinefile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jnafile@)@@cpsep@@nfp(@envvar(LIB_DIR)@/nqp.jar)@" -cp "@cur_dir@@envvar(LIB_DIR)@" nqp @sh_allparams@

--- a/tools/templates/jvm/nqp-j.in
+++ b/tools/templates/jvm/nqp-j.in
@@ -32,4 +32,4 @@ DIR=$(dirname -- "$EXEC")
 @setenv(JAR_DIR)@@q(@jar_dir@)@
 @setenv(LIB_DIR)@@q(@lib_dir@)@
 
-@exec(java)@ -Dnqp.execname="$EXEC" -Xss1m -Xmx1324m -Xbootclasspath/a:"@cur_dir@@envvar(LIB_DIR)@@cpsep@@nfp(@envvar(JAR_DIR)@/nqp-runtime.jar)@@cpsep@@nfp(@envvar(JAR_DIR)@/@asmfile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jlinefile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jnafile@)@@cpsep@@nfp(@envvar(LIB_DIR)@/nqp.jar)@" -cp "@cur_dir@@envvar(LIB_DIR)@" nqp @sh_allparams@
+@exec(java)@ -Dnqp.execname="$EXEC" -Xss1m -Xmx1324m -Xbootclasspath/a:"@cur_dir@@envvar(LIB_DIR)@@cpsep@@nfp(@envvar(JAR_DIR)@/nqp-runtime.jar)@@cpsep@@nfp(@envvar(JAR_DIR)@/@asmfile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jlinefile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jnafile@)@@cpsep@@nfp(@envvar(LIB_DIR)@/nqp.jar)@" -cp "@cur_dir@@envvar(LIB_DIR)@" nqp "@sh_allparams@"

--- a/tools/templates/jvm/nqp-j.windows
+++ b/tools/templates/jvm/nqp-j.windows
@@ -1,0 +1,4 @@
+@setenv(JAR_DIR)@@jar_dir@
+@setenv(LIB_DIR)@@lib_dir@
+
+@exec(java)@ -Dnqp.execname="%~dpf0" -Xss1m -Xmx1324m -Xbootclasspath/a:"@cur_dir@@envvar(LIB_DIR)@@cpsep@@nfp(@envvar(JAR_DIR)@/nqp-runtime.jar)@@cpsep@@nfp(@envvar(JAR_DIR)@/@asmfile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jlinefile@)@@cpsep@@nfp(@envvar(JAR_DIR)@/@jnafile@)@@cpsep@@nfp(@envvar(LIB_DIR)@/nqp.jar)@" -cp "@cur_dir@@envvar(LIB_DIR)@" nqp @sh_allparams@


### PR DESCRIPTION
Now that nqp and rakudo are relocatable we must not rely on a build time
path. The $NQP_HOME variable is the mechanism to retrieve the actual
runtime path.

This does *not* work yet. The $NQP_HOME variable is not yet set in NQP.