### PR TITLE
Register a plain HLL::Compiler object under the 'default' name

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -844,3 +844,4 @@ class HLL::Compiler does HLL::Backend::Default {
 
 my $compiler := HLL::Compiler.new();
 $compiler.language($compiler.backend.name);
+nqp::bindcomp('default', $compiler);

--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -699,7 +699,7 @@ class HLL::Backend::MoarVM {
         my str $template;
 
         if !$want_json && !$want_sql {
-            my $temppath := nqp::getcomp('nqp').nqp-home() ~ '/lib/profiler/template.html';
+            my $temppath := nqp::getcomp('default').nqp-home() ~ '/lib/profiler/template.html';
             $template := try slurp('src/vm/moar/profiler/template.html');
             unless $template {
                 $template := try slurp($temppath);


### PR DESCRIPTION
This allows the code in NQP to use functionality in the HLL Compiler.
Before that wasn't possible as it wasn't known which name the subclassed
Compiler object would have.

Use that generic name to access it from NQP code. In particular in the
logic that writes the `--profile` output.

This fixes rakudo/rakudo#3824

This is has received close to no testing. (But a simple `raku --profile -e "say 'hi'"` did work.) Also I don't know if it's a good way to expose the HLL::Compiler object in this way.