### PR TITLE
[JVM] Make osname available in nqp::backendconfig

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -817,13 +817,12 @@ class HLL::Compiler does HLL::Backend::Default {
     method nqp-home() {
         if !$!nqp-home {
             # Determine NQP directory
+            my $config := nqp::backendconfig();
+            my $sep := $config<osname> eq 'MSWin32' ?? '\\' !! '/';
 #?if jvm
-            my $sep := nqp::atkey(nqp::jvmgetproperties,'os.name') eq 'MSWin32' ?? '\\' !! '/';
             my $execname := nqp::atkey(nqp::jvmgetproperties,'nqp.execname') // '';
 #?endif
 #?if !jvm
-            my $config := nqp::backendconfig();
-            my $sep := $config<osname> eq 'MSWin32' ?? '\\' !! '/';
             my $execname := nqp::execname();
 #?endif
             my $install-dir := $execname eq ''

--- a/tools/build/gen-jvm-properties.pl
+++ b/tools/build/gen-jvm-properties.pl
@@ -53,4 +53,5 @@ nativecall.ldflags=$Config{ldflags}
 nativecall.lddlflags=$Config{lddlflags}
 nativecall.libs=$Config{libs}
 nativecall.perllibs=$Config{perllibs}
+osname=$^O
 END


### PR DESCRIPTION
This key is available on the other backends, and there are a couple
of special cases in Rakudo's code base because the operating system
name had to be taken from nqp::jvmgetproperties(){'os.name'}.