### PR TITLE
[JVM] Implement op 'execname'

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -820,6 +820,7 @@ class HLL::Compiler does HLL::Backend::Default {
             my $config := nqp::backendconfig();
             my $sep := $config<osname> eq 'MSWin32' ?? '\\' !! '/';
 #?if jvm
+            # TODO could be replaced by nqp::execname() after the next bootstrap for JVM
             my $execname := nqp::atkey(nqp::jvmgetproperties,'nqp.execname') // '';
 #?endif
 #?if !jvm

--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2874,6 +2874,7 @@ QAST::OperationsJAST.map_classlib_core_op('getenvhash', $TYPE_OPS, 'getenvhash',
 QAST::OperationsJAST.map_classlib_core_op('getpid', $TYPE_OPS, 'getpid', [], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('getppid', $TYPE_OPS, 'getppid', [], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('jvmgetproperties', $TYPE_OPS, 'jvmgetproperties', [], $RT_OBJ, :tc);
+QAST::OperationsJAST.map_classlib_core_op('execname', $TYPE_OPS, 'execname', [], $RT_STR, :tc);
 QAST::OperationsJAST.map_classlib_core_op('getrusage', $TYPE_OPS, 'getrusage', [$RT_OBJ], $RT_OBJ, :tc);
 
 # thread related opcodes

--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
@@ -5507,6 +5507,18 @@ public final class Ops {
         return res;
     }
 
+    public static String execname(ThreadContext tc) {
+        Properties env = System.getProperties();
+        if (env.containsKey("raku.execname"))
+            return env.getProperty("raku.execname");
+        else if (env.containsKey("perl6.execname"))
+            return env.getProperty("perl6.execname");
+        else if (env.containsKey("nqp.execname"))
+            return env.getProperty("nqp.execname");
+
+        return null;
+    }
+
     /* Thread related. */
     static class CodeRunnable implements Runnable {
         private GlobalContext gc;


### PR DESCRIPTION
This is a bit hacky, but it should enable us to use nqp::execname
in Rakudo's code base uniformly on all backends.

Currently we use nqp::jvmgetproperties(){nqp.execname} for NQP
and nqp::jvmgetproperties(){perl6.execname} for Rakudo.
Those properties are passed to the JVM via the runner scripts nqp-j
and rakudo-j, respectively.

I've also added support for raku.execname, so perl6.execname could
be easily removed in the future.