### PR TITLE
Support for typechecking against Raku roles

### DIFF
--- a/src/how/NQPClassHOW.nqp
+++ b/src/how/NQPClassHOW.nqp
@@ -454,8 +454,13 @@ knowhow NQPClassHOW {
         for self.mro($obj) {
             nqp::push(@tc, $_);
             if nqp::can($_.HOW, 'role_typecheck_list') {
-                for $_.HOW.role_typecheck_list($_) {
-                    nqp::push(@tc, $_);
+                for $_.HOW.role_typecheck_list($_) -> $role {
+                    nqp::push(@tc, $role);
+                    if nqp::can($role.HOW, 'role_typecheck_list') {
+                        for $role.HOW.role_typecheck_list($role) {
+                            nqp::push(@tc, $_);
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
If a `NQPClassHOW` class get a Raku role mixin then typechecking fails
for complex cases like parameterized roles. By incorporating
`role_typecheck_list` provided by role's HOW we fix the problem.

NQP, Rakudo, and roast tests are passing.