### PR TITLE
Add a HLL::SysConfig class

### DIFF
--- a/src/HLL/SysConfig.nqp
+++ b/src/HLL/SysConfig.nqp
@@ -1,0 +1,38 @@
+class HLL::SysConfig {
+    has %!build-config;
+    has $!nqp-home;
+    has $!path-sep;
+
+    method BUILD() {
+        %!build-config := nqp::hash();
+        hll-config(%!build-config);
+
+        $!path-sep := nqp::backendconfig<osname> eq 'MSWin32' ?? '\\' !! '/';
+
+        # Determine NQP home
+#?if jvm
+        # TODO could be replaced by nqp::execname() after the next bootstrap for JVM
+        my $execname := nqp::atkey(nqp::jvmgetproperties,'nqp.execname') // '';
+#?endif
+#?if !jvm
+        my $execname := nqp::execname;
+#?endif
+        my $install-dir := $execname eq ''
+            ?? %!build-config<prefix>
+            !! nqp::substr($execname, 0, nqp::rindex($execname, $!path-sep, nqp::rindex($execname, $!path-sep) - 1));
+
+        $!nqp-home := nqp::getenvhash<NQP_HOME>
+            // %!build-config<static-nqp-home>
+            || $install-dir ~ '/share/nqp';
+        if nqp::substr($!nqp-home, nqp::chars($!nqp-home) - 1) eq $!path-sep {
+            $!nqp-home := nqp::substr($!nqp-home, 0, nqp::chars($!nqp-home) - 1);
+        }
+    }
+
+    method path-sep() { $!path-sep }
+
+    method nqp-build-config() { %!build-config }
+
+    method nqp-home() { $!nqp-home }
+}
+

--- a/src/NQP/Compiler.nqp
+++ b/src/NQP/Compiler.nqp
@@ -13,7 +13,6 @@ my $nqpcomp := NQP::Compiler.new();
 $nqpcomp.language('nqp');
 $nqpcomp.parsegrammar(NQP::Grammar);
 $nqpcomp.parseactions(NQP::Actions);
-hll-config($nqpcomp.config);
 
 $nqpcomp.addstage('optimize', :after<ast>);
 

--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -699,7 +699,7 @@ class HLL::Backend::MoarVM {
         my str $template;
 
         if !$want_json && !$want_sql {
-            my $temppath := nqp::getcomp('default').nqp-home() ~ '/lib/profiler/template.html';
+            my $temppath := nqp::gethllsym('default', 'SysConfig').nqp-home() ~ '/lib/profiler/template.html';
             $template := try slurp('src/vm/moar/profiler/template.html');
             unless $template {
                 $template := try slurp($temppath);

--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -102,7 +102,7 @@
 @stage_gencat(@bpm(QASTNODE_COMBINED_@ucstage@)@:					@bsm(@ucstage@_DEPS)@ @use_prereqs($(QASTNODE_SOURCES))@)@
 @stage_gencat(@bpm(ASTNODES_COMBINED_@ucstage@)@:					@bsm(@ucstage@_DEPS)@ @use_prereqs(@bpm(ASTNODES_SOURCES)@)@)@
 @stage_gencat(@bpm(QREGEX_COMBINED_@ucstage@)@:						@bsm(@ucstage@_DEPS)@ @use_prereqs($(QREGEX_SOURCES))@)@
-@stage_gencat(@bpm(HLL_COMBINED_@ucstage@)@:						@bsm(@ucstage@_DEPS)@ @use_prereqs(@bpm(HLL_SOURCES)@)@)@
+@stage_gencat(@bpm(HLL_COMBINED_@ucstage@)@:						@bsm(@ucstage@_DEPS)@ @use_prereqs(@bpm(HLL_SOURCES)@ @nfp(@stage_dir@/nqp-config.nqp)@)@)@
 @stage_gencat(@bpm(QAST_COMBINED_@ucstage@)@:						@bsm(@ucstage@_DEPS)@ @use_prereqs(@bpm(QAST_SOURCES)@)@)@
 @stage_gencat(@bpm(P6QREGEX_COMBINED_@ucstage@)@:					@bsm(@ucstage@_DEPS)@ @use_prereqs($(P6QREGEX_SOURCES))@)@
 
@@ -117,10 +117,14 @@
 @stage_precomp(@bsm(QAST_@ucstage@)@:						@use_prereqs(@bpm(QAST_COMBINED_@ucstage@)@)@ @bsm(@ucstage@_DEPS)@ @bsm(HLL_@ucstage@)@ @bsm(ASTNODES_@ucstage@)@ @bsm(ASTOPS_@ucstage@)@ @bsm(QREGEX_@ucstage@)@ @bsm(QASTNODE_@ucstage@)@)@
 @stage_precomp(@bsm(P6QREGEX_@ucstage@)@:					@use_prereqs(@bpm(P6QREGEX_COMBINED_@ucstage@)@)@ @bsm(@ucstage@_DEPS)@ @bsm(HLL_@ucstage@)@ @bsm(QREGEX_@ucstage@)@ @bsm(QAST_@ucstage@)@ @bsm(QASTNODE_@ucstage@)@)@
 
+
+@nfp(@stage_dir@/nqp-config.nqp)@:
+	@echo(+++ Generating 	stage @stage@ nqp-config.nqp)@
+	$(NOECHO)$(PERL5) @shquot(@script(gen-version.pl)@)@ @q($(PREFIX))@ @q($(STATIC_NQP_HOME))@ @q($(NQP_LIB_DIR))@ > @nfpq(@stage_dir@/nqp-config.nqp)@
+
 @nfp(@stage_dir@/@bsm(NQP)@)@: @bsm(NQP_@ucprev_stage@)@ @nfp(@stage_dir@/@bsm(QAST)@)@ @nfp(@stage_dir@/@bsm(P6QREGEX)@)@ @bpm(SOURCES)@
 	@echo(+++ Creating	stage @stage@ NQP)@
-	$(NOECHO)$(PERL5) @shquot(@script(gen-version.pl)@)@ @q($(PREFIX))@ @q($(STATIC_NQP_HOME))@ @q($(NQP_LIB_DIR))@ > @nfpq(@stage_dir@/nqp-config.nqp)@
-	$(NOECHO@nop())@@bpm(@ucstage@_GEN_CAT)@ @bpm(NQP_SOURCES)@ @nfpq(@stage_dir@/nqp-config.nqp)@ > @nfpq(@stage_dir@/$(NQP_COMBINED))@
+	$(NOECHO@nop())@@bpm(@ucstage@_GEN_CAT)@ @bpm(NQP_SOURCES)@ > @nfpq(@stage_dir@/$(NQP_COMBINED))@
 	$(NOECHO@nop())@@bpm(@ucprev_stage@_NQP)@ --module-path=@shquot(@stage_dir@)@ --setting-path=@shquot(@stage_dir@)@ \
 	    --setting=NQPCORE --target=@btarget@ --no-regex-lib @bpm(PRECOMP_@ucstage@_FLAGS)@ @bpm(NQP_@ucstage@_FLAGS)@ \
 	    --output=@nfpq(@stage_dir@/@bsm(NQP)@)@ @nfpq(@stage_dir@/$(NQP_COMBINED))@

--- a/tools/templates/Makefile-common.in
+++ b/tools/templates/Makefile-common.in
@@ -5,6 +5,7 @@ COMMON_HLL_SOURCES = \
   @nfp(src/HLL/Grammar.nqp)@ \
   @nfp(src/HLL/Actions.nqp)@ \
   @nfp(src/HLL/Compiler.nqp)@ \
+  @nfp(src/HLL/SysConfig.nqp)@ \
   @nfp(src/HLL/CommandLine.nqp)@ \
   @nfp(src/HLL/World.nqp)@ \
   @nfp(src/HLL/sprintf.nqp)@ \


### PR DESCRIPTION
This class acts as a central point where configuration information is stored. The class should only ever be accessed via `nqp::gethllsym('default', 'SysConfig')`. This then allows the class to be overridden by a subclass.