### PR TITLE
[JVM] Default to empty string in nqp::execname

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
@@ -5516,7 +5516,7 @@ public final class Ops {
         else if (env.containsKey("nqp.execname"))
             return env.getProperty("nqp.execname");
 
-        return null;
+        return "";
     }
 
     /* Thread related. */


### PR DESCRIPTION
Otherwise we'd need an additional null check for the JVM backend,
while on other backends, we're just checking if nqp::execname()
gave an empty string.