### PR TITLE
Serialization format 23 for nqp-JS

### DIFF
--- a/src/vm/js/nqp-runtime/deserialization.js
+++ b/src/vm/js/nqp-runtime/deserialization.js
@@ -480,10 +480,11 @@ class BinaryCursor {
       const objectIndex = this.int32();
       entry.codeObj = this.sc.deps[objectScId].rootObjects[objectIndex];
     } else {
-      // we're packed along a 24-byte alignment
+      // we're packed along a 28-byte alignment
       this.int32();
       this.int32();
     }
+    entry.name = this.str32();
     return entry;
   }
 
@@ -540,7 +541,7 @@ class BinaryCursor {
 
     this.sc = sc;
 
-    if (version != 22) {
+    if (version != 23) {
       throw 'Unsupported serialization format version: ' + version;
     }
 

--- a/src/vm/js/nqp-runtime/serialization.js
+++ b/src/vm/js/nqp-runtime/serialization.js
@@ -25,7 +25,7 @@ const globalContext = require('./global-context.js');
 const op = {};
 exports.op = op;
 
-const CURRENT_VERSION = 22;
+const CURRENT_VERSION = 23;
 const OBJECTS_TABLE_ENTRY_SC_IDX_MAX = 0x000FFFFF;
 const OBJECTS_TABLE_ENTRY_SC_MAX = 0x7FE;
 const OBJECTS_TABLE_ENTRY_SC_SHIFT = 20;
@@ -758,6 +758,7 @@ class SerializationWriter {
       this.closures.int32(0);
       this.closures.int32(0);
     }
+    this.closures.str32(this.name);
 
     /* Increment count of closures in the table. */
     this.numClosures++;


### PR DESCRIPTION
nqp-JS is currently a cross-compiler, and so needs to be able to read the serialization output of MoarVM. As of Feb 2020, commit 9709537d90d61529 the MoarVM serialization format was bumped from version 22 to version 23, as it now also serializes closure names.

This broke the nqp-JS build, but it seems that no-one noticed.

This fixes the build at 2020-07 (the current release), but unfortunately additional fixes are needed for changes now made on master. (report coming soon)

With this commit atop `2020-07` I still see these test failures:

```
Test Summary Report
-------------------
t/nqp/060-bigint.t                   (Wstat: 0 Tests: 157 Failed: 2)
  Failed tests:  96-97
t/nqp/100-dispatcher.t               (Wstat: 0 Tests: 16 Failed: 3)
  Failed tests:  6, 10, 14
t/nqp/114-pod-panic.t                (Wstat: 0 Tests: 0 Failed: 0)
  Parse errors: Bad plan.  You planned 1 tests but ran 0.
t/hll/06-sprintf.t                   (Wstat: 0 Tests: 284 Failed: 12)
  Failed tests:  40, 66-76
  Parse errors: Bad plan.  You planned 294 tests but ran 284.
Files=116, Tests=11601, 236 wallclock secs ( 2.54 usr  0.42 sys + 303.40 cusr 21.92 csys = 328.28 CPU)
Result: FAIL
```

`t/nqp/060-bigint.t` and `t/hll/06-sprintf.t` were both also failing in the same way immediately prior to MoarVM commit 9709537d90d61529.

`t/nqp/100-dispatcher.t` fails new tests added after later by commit aadea88670b45ffc84cae0c827c7c0ffbff4ecd7 -- Add nextdispatcherfor/takenextdispatcher ops. Specifically it fails with `Trace: NYI: unimplemented QAST::Op nextdispatcherfor` and `Trace: NYI: unimplemented QAST::Op takenextdispatcher`

`t/nqp/114-pod-panic.t` fails as a result of

```
commit c4fcc6438d8d6061dcd3ae431d2771f7c58c4c5d
Date:   Fri May 29 20:45:03 2020 +0200

    Fix t/nqp/114-pod-panic with a relocated `nqp` executable

    As `nqp::execname` is an op code not available on JVM and thus resulting
    in a compile time error, a quite dirty workaround is used. We hide the op
    in an eval and retrieve the value via `die`.

    Also there is no sane way to retrieve the current nqp executable name
    available on the JVM, so skip that test there.

 t/nqp/114-pod-panic.t | 49 ++++++++++++++++++++++++++++---------------------
 1 file changed, 28 insertions(+), 21 deletions(-)
```

It's unclear what the correct fix for that should be - clearly nqp doesn't work totally cleanly as a cross-compiler.