### PR TITLE
Move build logic to separate method so it can be called in subclasses

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -816,4 +816,3 @@ class HLL::Compiler does HLL::Backend::Default {
 my $compiler := HLL::Compiler.new();
 $compiler.language($compiler.backend.name);
 nqp::bindcomp('default', $compiler);
-nqp::bindhllsym('default', 'SysConfig', HLL::SysConfig.new());

--- a/src/HLL/SysConfig.nqp
+++ b/src/HLL/SysConfig.nqp
@@ -4,6 +4,10 @@ class HLL::SysConfig {
     has $!path-sep;
 
     method BUILD() {
+        self.build-hll-sysconfig()
+    }
+
+    method build-hll-sysconfig() {
         %!build-config := nqp::hash();
         hll-config(%!build-config);
 

--- a/src/NQP/Compiler.nqp
+++ b/src/NQP/Compiler.nqp
@@ -8,6 +8,8 @@ class NQP::Compiler is HLL::Compiler {
     }
 }
 
+nqp::bindhllsym('default', 'SysConfig', HLL::SysConfig.new());
+
 # Create and configure compiler object.
 my $nqpcomp := NQP::Compiler.new();
 $nqpcomp.language('nqp');


### PR DESCRIPTION
This is a support PR for [rakudo/rakudo#3913](https://github.com/rakudo/rakudo/pull/3913).
Do not merge. The PR might possibly not be needed in the end.