### PR TITLE
[JVM] Use singleton object for VMnull

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
@@ -128,6 +128,7 @@ import org.raku.nqp.sixmodel.reprs.VMHash;
 import org.raku.nqp.sixmodel.reprs.VMHashInstance;
 import org.raku.nqp.sixmodel.reprs.VMIterInstance;
 import org.raku.nqp.sixmodel.reprs.VMNull;
+import org.raku.nqp.sixmodel.reprs.VMNullInstance;
 import org.raku.nqp.sixmodel.reprs.VMThreadInstance;
 
 import sun.misc.Unsafe;
@@ -158,6 +159,8 @@ public final class Ops {
             // ignore (that's the raison d'être for this method)
         }
     }
+
+    private static SixModelObject theVMNull = null;
 
     /* I/O opcodes */
     public static String print(String v, ThreadContext tc) {
@@ -2349,11 +2352,12 @@ public final class Ops {
         return a == b ? 1 : 0;
     }
     public static SixModelObject createNull(ThreadContext tc) {
-        SixModelObject vmnull = tc.gc.VMNull.st.REPR.allocate(tc, tc.gc.VMNull.st);
-        return vmnull;
+        if (theVMNull == null)
+            theVMNull = VMNullInstance.getInstance(tc);
+        return theVMNull;
     }
     public static long isnull(SixModelObject obj) {
-        return obj == null || (obj.st != null && obj.st.REPR instanceof VMNull) ? 1 : 0;
+        return obj == null || obj == theVMNull ? 1 : 0;
     }
     public static long isnull_s(String str) {
         return str == null ? 1 : 0;

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMNull.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMNull.java
@@ -20,9 +20,7 @@ public class VMNull extends REPR {
 
     @Override
     public SixModelObject allocate(ThreadContext tc, STable st) {
-        VMNullInstance obj = new VMNullInstance();
-        obj.st = st;
-        return obj;
+        return VMNullInstance.getInstance(tc);
     }
 
     @Override

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMNullInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMNullInstance.java
@@ -1,6 +1,25 @@
 package org.raku.nqp.sixmodel.reprs;
 
+import org.raku.nqp.runtime.ThreadContext;
 import org.raku.nqp.sixmodel.SixModelObject;
 
 public class VMNullInstance extends SixModelObject {
+    // singleton object
+    private static volatile VMNullInstance theVMNull;
+
+    private VMNullInstance(ThreadContext tc) {
+        this.st = tc.gc.VMNull.st;
+    }
+
+    public synchronized static VMNullInstance getInstance(ThreadContext tc) {
+        // double check to make singleton thread safe
+        if (theVMNull == null) {
+            synchronized (VMNullInstance.class) {
+                if (theVMNull == null)
+                    theVMNull = new VMNullInstance(tc);
+            }
+        }
+
+        return theVMNull;
+    }
 }


### PR DESCRIPTION
When I introduced the VMNull for the JVM backend (https://github.com/Raku/nqp/pull/605), @pmurias++ suggested to use a null singleton. I'm not sure my change matches what he aimed at, though.