### PR TITLE
Please do not merge: Add more tests for streaming decoder and fixes for JVM

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
@@ -329,7 +329,7 @@ public class DecoderInstance extends SixModelObject {
                 ByteBuffer use = toDecode.get(0);
 
                 CoderResult result = decoder.decode(use, target, eof && toDecode.size() == 1);
-                if (result.isError() && !maybeEndsWithIncompleteChar(use))
+                if (result.isError() && (eof || !maybeEndsWithIncompleteChar(use)))
                     result.throwException();
 
                 if (use.position() == use.limit())

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
@@ -329,7 +329,7 @@ public class DecoderInstance extends SixModelObject {
                 ByteBuffer use = toDecode.get(0);
 
                 CoderResult result = decoder.decode(use, target, eof && toDecode.size() == 1);
-                if (result.isError() && (eof || !maybeEndsWithIncompleteChar(use)))
+                if (result.isError())
                     result.throwException();
 
                 if (use.position() == use.limit())
@@ -338,82 +338,6 @@ public class DecoderInstance extends SixModelObject {
                     break;
             }
         }
-    }
-
-    private boolean maybeEndsWithIncompleteChar(ByteBuffer use) {
-        // FIXME support other charsets with multibyte characters
-        if (charset.toString().equals("UTF-8")) {
-            int remainingBytes = use.remaining();
-            if (remainingBytes < MAX_BYTES_PER_CHAR_UTF8) {
-                // Look at first byte to determine expected length.
-                // See Unicode Standard, Chapter 3, Table 3-7 Well-Formed UTF-8 Byte Sequences
-                // http://www.unicode.org/versions/Unicode13.0.0/ch03.pdf#G7404
-                int len = -1;
-                int firstByte = use.get(use.position()) & 0xFF;
-                if (firstByte < 0x80)
-                    len = 1;
-                else if (firstByte >= 0xC2 && firstByte <= 0xDF)
-                    len = 2;
-                else if (firstByte >= 0xE0 && firstByte <= 0xEF)
-                    len = 3;
-                else if (firstByte >= 0xF0 && firstByte <= 0xF4)
-                    len = 4;
-
-                // If we have enough bytes, we can't have an incomplete char.
-                if (len <= remainingBytes)
-                    return false;
-
-                // At this point we only have to think about characters with
-                // three or with four bytes.
-
-                // If we have a second byte we can see if it's invalid.
-                if (remainingBytes >= 2) {
-                    int secondByte = use.get(use.position() + 1) & 0xFF;
-                    // Validity of second bytes depends on first byte
-                    if (firstByte < 0xE1) {
-                        if (secondByte < 0xA0 || secondByte > 0xBF)
-                            return false;
-                    }
-                    else if (firstByte < 0xED) {
-                        if (secondByte < 0x80 || secondByte > 0xBF)
-                            return false;
-                    }
-                    else if (firstByte < 0xEE) {
-                        if (secondByte < 0x80 || secondByte > 0x9F)
-                            return false;
-                    }
-                    else if (firstByte < 0xF0) {
-                        if (secondByte < 0x80 || secondByte > 0xBF)
-                            return false;
-                    }
-                    else if (firstByte < 0xF1) {
-                        if (secondByte < 0x90 || secondByte > 0xBF)
-                            return false;
-                    }
-                    else if (firstByte < 0xF4) {
-                        if (secondByte < 0x80 || secondByte > 0xBF)
-                            return false;
-                    }
-                    else {
-                        if (secondByte < 0x80 || secondByte > 0x8F)
-                            return false;
-                    }
-                }
-
-                // If we have a third byte we can see if it's invalid.
-                if (remainingBytes == 3) {
-                    int thirdByte = use.get(use.position() + 2) & 0xFF;
-                    if (thirdByte < 0x80 || thirdByte > 0xBF)
-                        return false;
-                }
-
-                // If we reach this, we didn't encounter invalid bytes, but
-                // don't have enough bytes to verify the character.
-                return true;
-            }
-        }
-
-        return false;
     }
 
     private boolean isNormTerminated(String s) {

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
@@ -56,8 +56,14 @@ public class DecoderInstance extends SixModelObject {
         ensureConfigured(tc);
         if (toDecode == null)
             toDecode = new ArrayList<ByteBuffer>();
-        if (bytes.remaining() > 0)
-            toDecode.add(bytes);
+        if (bytes.remaining() > 0) {
+            ByteBuffer clone = ByteBuffer.allocate(bytes.capacity());
+            bytes.rewind();
+            clone.put(bytes);
+            bytes.rewind();
+            clone.flip();
+            toDecode.add(clone);
+        }
     }
 
     public synchronized String takeChars(ThreadContext tc, long chars, boolean eof) {

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
@@ -118,7 +118,7 @@ public class DecoderInstance extends SixModelObject {
         CharBuffer target = CharBuffer.allocate(maxChars);
         eatAllDecodedChars(target);
         try {
-            eatUndecodedBytes(target, true);
+            eatUndecodedBytes(target, false);
         }
         catch (MalformedInputException e) {
             Ops.die_s("Will not decode invalid " + charset, tc);

--- a/t/nqp/116-streaming-decoder.t
+++ b/t/nqp/116-streaming-decoder.t
@@ -70,13 +70,8 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     nqp::bindpos_i($testbuf1, 1, 0x78); # 'x'
     nqp::bindpos_i($testbuf1, 2, 0x78); # 'x'
     nqp::decoderaddbytes($dec, $testbuf1);
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('currently nqp-j reports "xxxxxx"', 1);
-    }
-    else {
-        ok(nqp::decodertakeallchars($dec) eq 'nqpxxx',
-            'internal buffer of decoder gets its own copy of the added bytes');
-    }
+    ok(nqp::decodertakeallchars($dec) eq 'nqpxxx',
+        'internal buffer of decoder gets its own copy of the added bytes');
 }
 
 {

--- a/t/nqp/116-streaming-decoder.t
+++ b/t/nqp/116-streaming-decoder.t
@@ -207,16 +207,7 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     nqp::decoderaddbytes($dec, $testbuf2);
     nqp::bindpos_i($testbuf2, 0, 0xB4);
     nqp::decoderaddbytes($dec, $testbuf2);
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('not able to cope with separately pushed bytes: "Will not decode invalid UTF-8"', 1);
-        ## restore old state (needed because of earlier failure)
-        ## java.lang.IllegalStateException: Current state = CODING, new state = FLUSHED
-        $dec := nqp::create(VMDecoder);
-        nqp::decoderconfigure($dec, 'utf8', nqp::hash());
-    }
-    else {
-        ok(nqp::decodertakeallchars($dec) eq 'д', 'Got valid code point back (bytes pushed separately)');
-    }
+    ok(nqp::decodertakeallchars($dec) eq 'д', 'Got valid code point back (bytes pushed separately)');
 
     ## try to decode incomplete code point
     nqp::bindpos_i($testbuf2, 0, 0xD0);
@@ -237,16 +228,7 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     ## push second byte to complete code point
     nqp::bindpos_i($testbuf2, 0, 0xB4);
     nqp::decoderaddbytes($dec, $testbuf2);
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('Will not decode invalid UTF-8', 1);
-        ## restore old state (needed because of earlier failure)
-        ## java.lang.IllegalStateException: Current state = CODING, new state = FLUSHED
-        $dec := nqp::create(VMDecoder);
-        nqp::decoderconfigure($dec, 'utf8', nqp::hash());
-    }
-    else {
-        ok(nqp::decodertakeallchars($dec) eq 'д', 'Got valid code point back after pushing second byte');
-    }
+    ok(nqp::decodertakeallchars($dec) eq 'д', 'Got valid code point back after pushing second byte');
 
     ## push invalid code point (second byte of multibyte character must by larger than 0x7F)
     nqp::bindpos_i($testbuf1, 0, 0xD0);
@@ -259,12 +241,7 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     nqp::decoderaddbytes($dec, $testbuf2);
     nqp::bindpos_i($testbuf2, 0, 0x7F);
     nqp::decoderaddbytes($dec, $testbuf2);
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('returns empty string', 1);
-    }
-    else {
-        dies-ok({ nqp::decodertakeallchars($dec) }, 'error with invalid code point (bytes pushed separately)');
-    }
+    dies-ok({ nqp::decodertakeallchars($dec) }, 'error with invalid code point (bytes pushed separately)');
 }
 
 {

--- a/t/nqp/116-streaming-decoder.t
+++ b/t/nqp/116-streaming-decoder.t
@@ -212,18 +212,7 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     ## try to decode incomplete code point
     nqp::bindpos_i($testbuf2, 0, 0xD0);
     nqp::decoderaddbytes($dec, $testbuf2);
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('Will not decode invalid UTF-8', 1);
-        ## restore old state (needed because of earlier failure)
-        ## java.lang.IllegalStateException: Current state = CODING, new state = FLUSHED
-        $dec := nqp::create(VMDecoder);
-        nqp::decoderconfigure($dec, 'utf8', nqp::hash());
-        nqp::bindpos_i($testbuf2, 0, 0xD0);
-        nqp::decoderaddbytes($dec, $testbuf2);
-    }
-    else {
-        ok(nqp::decodertakeallchars($dec) eq '', 'Got empty string from incomplete code point');
-    }
+    ok(nqp::decodertakeallchars($dec) eq '', 'Got empty string from incomplete code point');
 
     ## push second byte to complete code point
     nqp::bindpos_i($testbuf2, 0, 0xB4);
@@ -249,13 +238,8 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     my $dec := nqp::create(VMDecoder);
     nqp::decoderconfigure($dec, 'utf8', nqp::hash());
     nqp::decoderaddbytes($dec, nqp::slice($testbuf, 0, 0));
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('Will not decode invalid UTF-8', 1);
-    }
-    else {
-        ok(nqp::decodertakeallchars($dec) eq '',
-            'Got "" after 1st byte (no complaint about invalid UTF-8)');
-    }
+    ok(nqp::decodertakeallchars($dec) eq '',
+        'Got "" after 1st byte (no complaint about invalid UTF-8)');
 
     $dec := nqp::create(VMDecoder);
     nqp::decoderconfigure($dec, 'utf8', nqp::hash());
@@ -266,13 +250,8 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     $dec := nqp::create(VMDecoder);
     nqp::decoderconfigure($dec, 'utf8', nqp::hash());
     nqp::decoderaddbytes($dec, nqp::slice($testbuf, 0, 2));
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('Will not decode invalid UTF-8', 1);
-    }
-    else {
-        ok(nqp::decodertakeallchars($dec) eq 'д',
-            'Got "д" after 3rd byte (no complaint about invalid UTF-8)');
-    }
+    ok(nqp::decodertakeallchars($dec) eq 'д',
+        'Got "д" after 3rd byte (no complaint about invalid UTF-8)');
 
     $dec := nqp::create(VMDecoder);
     nqp::decoderconfigure($dec, 'utf8', nqp::hash());
@@ -283,13 +262,8 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     $dec := nqp::create(VMDecoder);
     nqp::decoderconfigure($dec, 'utf8', nqp::hash());
     nqp::decoderaddbytes($dec, nqp::slice($testbuf, 0, 4));
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('Will not decode invalid UTF-8', 1);
-    }
-    else {
-        ok(nqp::decodertakeallchars($dec) eq 'дв',
-            'Got "дв" after 5th byte (no complaint about invalid UTF-8)');
-    }
+    ok(nqp::decodertakeallchars($dec) eq 'дв',
+        'Got "дв" after 5th byte (no complaint about invalid UTF-8)');
 
     $dec := nqp::create(VMDecoder);
     nqp::decoderconfigure($dec, 'utf8', nqp::hash());
@@ -304,22 +278,12 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     nqp::decoderconfigure($dec, 'utf8', nqp::hash());
     my $bufpart1 := nqp::slice($testbuf, 0, 8);
     nqp::decoderaddbytes($dec, $bufpart1);
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('Will not decode invalid UTF-8', 1);
-    }
-    else {
-        ok(nqp::decodertakeavailablechars($dec) eq 'под',
-            'Got first three chars ("в" held by normalization, first byte of "о" not valid)');
-    }
+    ok(nqp::decodertakeavailablechars($dec) eq 'под',
+        'Got first three chars ("в" held by normalization, first byte of "о" not valid)');
     my $bufpart2 := nqp::slice($testbuf, 9, 16);
     nqp::decoderaddbytes($dec, $bufpart2);
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('wrong result caused by earlier failure', 1);
-    }
-    else {
-        ok(nqp::decodertakeavailablechars($dec) eq "водка\n",
-            'Got remaining chars, no complaint about invalid UTF-8 after more bytes are added');
-    }
+    ok(nqp::decodertakeavailablechars($dec) eq "водка\n",
+        'Got remaining chars, no complaint about invalid UTF-8 after more bytes are added');
 }
 
 {
@@ -327,29 +291,24 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     my $dec := nqp::create(VMDecoder);
     nqp::decoderconfigure($dec, 'utf8', nqp::hash());
     nqp::decoderaddbytes($dec, nqp::slice($testbuf, 0, 0));
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('Will not decode invalid UTF-8', 7);
-    }
-    else {
-        ok(nqp::decodertakeavailablechars($dec) eq '',
-            'No valid char after 1st byte (first byte of "д" not valid)');
-        nqp::decoderaddbytes($dec, nqp::slice($testbuf, 1, 1));
-        ok(nqp::decodertakeavailablechars($dec) eq '',
-            'No valid char after 2nd byte ("д" held by normalization)');
-        nqp::decoderaddbytes($dec, nqp::slice($testbuf, 2, 2));
-        ok(nqp::decodertakeavailablechars($dec) eq '',
-            'No valid char after 3rd byte ("д" held by normalization, first byte of "в" not valid');
-        nqp::decoderaddbytes($dec, nqp::slice($testbuf, 3, 3));
-        ok(nqp::decodertakeavailablechars($dec) eq 'д',
-            'Got "д" after 4th byte ("в" held by normalization)');
-        nqp::decoderaddbytes($dec, nqp::slice($testbuf, 4, 4));
-        ok(nqp::decodertakeavailablechars($dec) eq '',
-            'No valid char after 5th byte ("в" held by normalization, first byte of "а" not valid');
-        nqp::decoderaddbytes($dec, nqp::slice($testbuf, 5, 5));
-        ok(nqp::decodertakeavailablechars($dec) eq 'в',
-            'Got "в" after 6th byte ("а" held by normalization)');
-        nqp::decoderaddbytes($dec, nqp::slice($testbuf, 6, 6));
-        ok(nqp::decodertakeavailablechars($dec) eq "а\n",
-            'Got "а\n" after 7th byte');
-    }
+    ok(nqp::decodertakeavailablechars($dec) eq '',
+        'No valid char after 1st byte (first byte of "д" not valid)');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 1, 1));
+    ok(nqp::decodertakeavailablechars($dec) eq '',
+        'No valid char after 2nd byte ("д" held by normalization)');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 2, 2));
+    ok(nqp::decodertakeavailablechars($dec) eq '',
+        'No valid char after 3rd byte ("д" held by normalization, first byte of "в" not valid');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 3, 3));
+    ok(nqp::decodertakeavailablechars($dec) eq 'д',
+        'Got "д" after 4th byte ("в" held by normalization)');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 4, 4));
+    ok(nqp::decodertakeavailablechars($dec) eq '',
+        'No valid char after 5th byte ("в" held by normalization, first byte of "а" not valid');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 5, 5));
+    ok(nqp::decodertakeavailablechars($dec) eq 'в',
+        'Got "в" after 6th byte ("а" held by normalization)');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 6, 6));
+    ok(nqp::decodertakeavailablechars($dec) eq "а\n",
+        'Got "а\n" after 7th byte');
 }


### PR DESCRIPTION
... a lot of them skipped for the JVM backend.

Adding these tests might introduce some redundancy (both, within
the new tests and in combination with the existing tests). But
each block exercises a specific functionality and shows existing
problems on the JVM backend (not covered by tests before). So some
redundancy should be ok.