### PR TITLE
Improve streaming decoder on the JVM backend

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
@@ -313,8 +313,20 @@ public class DecoderInstance extends SixModelObject {
                 if (result.isError())
                     result.throwException();
 
-                if (use.position() == use.limit())
+                if (use.position() == use.limit()) {
                     toDecode.remove(0);
+                }
+                else if (toDecode.size() > 1) {
+                    // We might have to merge the remaining bytes with those
+                    // in the next element of toDecode to get a valid char.
+                    ByteBuffer useFirst = toDecode.get(0);
+                    ByteBuffer useSecond = toDecode.get(1);
+                    int size = useFirst.remaining() + useSecond.remaining();
+                    ByteBuffer useCombined = ByteBuffer.allocate(size).put(useFirst).put(useSecond);
+                    useCombined.rewind();
+                    toDecode.remove(0);
+                    toDecode.set(0, useCombined);
+                }
                 else
                     break;
             }

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
@@ -116,7 +116,7 @@ public class DecoderInstance extends SixModelObject {
         CharBuffer target = CharBuffer.allocate(maxChars);
         eatAllDecodedChars(target);
         try {
-            eatUndecodedBytes(target, true);
+            eatUndecodedBytes(target, false);
         }
         catch (MalformedInputException e) {
             Ops.die_s("Will not decode invalid " + charset, tc);

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
@@ -56,8 +56,14 @@ public class DecoderInstance extends SixModelObject {
         ensureConfigured(tc);
         if (toDecode == null)
             toDecode = new ArrayList<ByteBuffer>();
-        if (bytes.remaining() > 0)
-            toDecode.add(bytes);
+        if (bytes.remaining() > 0) {
+            ByteBuffer clone = ByteBuffer.allocate(bytes.capacity());
+            bytes.rewind();
+            clone.put(bytes);
+            bytes.rewind();
+            clone.flip();
+            toDecode.add(clone);
+        }
     }
 
     public synchronized String takeChars(ThreadContext tc, long chars, boolean eof) {

--- a/t/nqp/116-streaming-decoder.t
+++ b/t/nqp/116-streaming-decoder.t
@@ -1,4 +1,4 @@
-plan(55);
+plan(70);
 
 sub dies-ok(&code, $message) {
     my int $died := 0;
@@ -189,4 +189,101 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     nqp::decoderconfigure($dec, 'utf8', nqp::hash());
     nqp::decoderaddbytes($dec, $emptybuf);
     ok(nqp::decoderempty($dec), 'Decoder is still empty after adding an empty buffer');
+}
+
+{
+    ## 'д' is 'CYRILLIC SMALL LETTER DE', (U+0434), UFT-8(hex) 0xD0 0xB4
+    my $testbuf1 := nqp::create($buf_type);
+    my $testbuf2 := nqp::create($buf_type);
+    my $dec := nqp::create(VMDecoder);
+    nqp::decoderconfigure($dec, 'utf8', nqp::hash());
+
+    ## decode complete code point
+    nqp::bindpos_i($testbuf1, 0, 0xD0);
+    nqp::bindpos_i($testbuf1, 1, 0xB4);
+    nqp::decoderaddbytes($dec, $testbuf1);
+    ok(nqp::decodertakeallchars($dec) eq 'д', 'Got valid code point back (bytes pushed together)');
+    nqp::bindpos_i($testbuf2, 0, 0xD0);
+    nqp::decoderaddbytes($dec, $testbuf2);
+    nqp::bindpos_i($testbuf2, 0, 0xB4);
+    nqp::decoderaddbytes($dec, $testbuf2);
+    ok(nqp::decodertakeallchars($dec) eq 'д', 'Got valid code point back (bytes pushed separately)');
+
+    ## push invalid code point (second byte of multibyte character must by larger than 0x7F)
+    nqp::bindpos_i($testbuf1, 0, 0xD0);
+    nqp::bindpos_i($testbuf1, 1, 0x7F);
+    nqp::decoderaddbytes($dec, $testbuf1);
+    dies-ok({ nqp::decodertakeallchars($dec) }, 'error with invalid code point (bytes pushed together)');
+    $dec := nqp::create(VMDecoder);
+    nqp::decoderconfigure($dec, 'utf8', nqp::hash());
+    nqp::bindpos_i($testbuf2, 0, 0xD0);
+    nqp::decoderaddbytes($dec, $testbuf2);
+    nqp::bindpos_i($testbuf2, 0, 0x7F);
+    nqp::decoderaddbytes($dec, $testbuf2);
+    dies-ok({ nqp::decodertakeallchars($dec) }, 'error with invalid code point (bytes pushed separately)');
+}
+
+{
+    my $testbuf := nqp::encode("два\n", 'utf8', nqp::create($buf_type));
+    my $dec := nqp::create(VMDecoder);
+    nqp::decoderconfigure($dec, 'utf8', nqp::hash());
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 0, 0));
+    ok(nqp::decodertakeavailablechars($dec) eq '',
+        'No valid char after 1st byte (first byte of "д" not valid)');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 1, 1));
+    ok(nqp::decodertakeavailablechars($dec) eq '',
+        'No valid char after 2nd byte ("д" held by normalization)');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 2, 2));
+    ok(nqp::decodertakeavailablechars($dec) eq '',
+        'No valid char after 3rd byte ("д" held by normalization, first byte of "в" not valid');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 3, 3));
+    ok(nqp::decodertakeavailablechars($dec) eq 'д',
+        'Got "д" after 4th byte ("в" held by normalization)');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 4, 4));
+    ok(nqp::decodertakeavailablechars($dec) eq '',
+        'No valid char after 5th byte ("в" held by normalization, first byte of "а" not valid');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 5, 5));
+    ok(nqp::decodertakeavailablechars($dec) eq 'в',
+        'Got "в" after 6th byte ("а" held by normalization)');
+    nqp::decoderaddbytes($dec, nqp::slice($testbuf, 6, 6));
+    ok(nqp::decodertakeavailablechars($dec) eq "а\n",
+        'Got "а\n" after 7th byte');
+}
+
+{
+    my $testbuf := nqp::encode("подводка\n", 'utf8', nqp::create($buf_type));
+    my $dec := nqp::create(VMDecoder);
+    nqp::decoderconfigure($dec, 'utf8', nqp::hash());
+    my $bufpart1 := nqp::slice($testbuf, 0, 8);
+    nqp::decoderaddbytes($dec, $bufpart1);
+    ok(nqp::decodertakeavailablechars($dec) eq 'под',
+        'Got first three chars ("в" held by normalization, first byte of "о" not valid)');
+    my $bufpart2 := nqp::slice($testbuf, 9, 16);
+    nqp::decoderaddbytes($dec, $bufpart2);
+    ok(nqp::decodertakeavailablechars($dec) eq "водка\n",
+        'Got remaining chars, no complaint about invalid UTF-8 after more bytes are added');
+}
+
+{
+    my $testbuf := nqp::encode("подводка\n", 'utf8', nqp::create($buf_type));
+    my $dec := nqp::create(VMDecoder);
+    nqp::decoderconfigure($dec, 'utf8', nqp::hash());
+    my $bufpart1 := nqp::slice($testbuf, 0, 8);
+    nqp::decoderaddbytes($dec, $bufpart1);
+    my $bufpart2 := nqp::slice($testbuf, 9, 16);
+    nqp::decoderaddbytes($dec, $bufpart2);
+    ok(nqp::decodertakeavailablechars($dec) eq "подводка\n",
+        'Got complete string from decodertakeavailablechars (string pushed in two parts, split on multibyte char)');
+}
+
+{
+    my $testbuf := nqp::encode("подводка\n", 'utf8', nqp::create($buf_type));
+    my $dec := nqp::create(VMDecoder);
+    nqp::decoderconfigure($dec, 'utf8', nqp::hash());
+    my $bufpart1 := nqp::slice($testbuf, 0, 8);
+    nqp::decoderaddbytes($dec, $bufpart1);
+    my $bufpart2 := nqp::slice($testbuf, 9, 16);
+    nqp::decoderaddbytes($dec, $bufpart2);
+    ok(nqp::decodertakeallchars($dec) eq "подводка\n",
+        'Got complete string from decodertakeallchars (string pushed in two parts, split on multibyte char)');
 }

--- a/t/nqp/116-streaming-decoder.t
+++ b/t/nqp/116-streaming-decoder.t
@@ -1,4 +1,4 @@
-plan(54);
+plan(55);
 
 sub dies-ok(&code, $message) {
     my int $died := 0;
@@ -56,6 +56,22 @@ nqp::composetype($buf_type, nqp::hash('array', nqp::hash('type', uint8)));
     ok(!nqp::decoderempty($dec), 'Not empty after adding a second');
     ok(nqp::decodertakeallchars($dec) eq 'omgwtfbbq', 'Can take all chars');
     ok(nqp::decoderempty($dec), 'Empty again after taking all chars');
+}
+
+{
+    my $testbuf1 := nqp::create($buf_type);
+    my $dec := nqp::create(VMDecoder);
+    nqp::decoderconfigure($dec, 'ascii', nqp::hash());
+    nqp::bindpos_i($testbuf1, 0, 0x6E); # 'n'
+    nqp::bindpos_i($testbuf1, 1, 0x71); # 'q'
+    nqp::bindpos_i($testbuf1, 2, 0x70); # 'p'
+    nqp::decoderaddbytes($dec, $testbuf1);
+    nqp::bindpos_i($testbuf1, 0, 0x78); # 'x'
+    nqp::bindpos_i($testbuf1, 1, 0x78); # 'x'
+    nqp::bindpos_i($testbuf1, 2, 0x78); # 'x'
+    nqp::decoderaddbytes($dec, $testbuf1);
+    ok(nqp::decodertakeallchars($dec) eq 'nqpxxx',
+        'internal buffer of decoder gets its own copy of the added bytes');
 }
 
 {


### PR DESCRIPTION
Fixes https://github.com/Raku/nqp/issues/668

The added tests might introduce some redundancy (both, within
the new tests and in combination with the existing tests). But
each block exercises a specific functionality and shows existing
problems on the JVM backend (not covered by tests before).