### PR TITLE
Adapt tests to new `nqp::spawnprocasync` semantics

### DIFF
--- a/src/core/testing.nqp
+++ b/src/core/testing.nqp
@@ -90,6 +90,10 @@ sub run-command($command, :$stdout, :$stderr) {
     my $read-all2    := 0;
     my $called-ready := 0;
 
+    # Add the program to call to the start of the command.
+    my @spawn-args := nqp::clone($command);
+    nqp::unshift(@spawn-args, $command[0]);
+
     my $config := nqp::hash();
     $config<done> := -> $status {
         ++$done;
@@ -122,7 +126,7 @@ sub run-command($command, :$stdout, :$stderr) {
     }
 
     # define the task
-    my $task := nqp::spawnprocasync($queue, $command, nqp::cwd(),
+    my $task := nqp::spawnprocasync($queue, @spawn-args, nqp::cwd(),
         nqp::getenvhash(), $config);
     nqp::permit($task, 1, -1);
     nqp::permit($task, 2, -1);

--- a/t/nqp/111-spawnprocasync.t
+++ b/t/nqp/111-spawnprocasync.t
@@ -57,8 +57,8 @@ my $config := nqp::hash(
 # define a task
 $string  := "expected output from stdout";
 $command := "echo $string";
-$args := $is-windows ?? nqp::list(nqp::getenvhash()<ComSpec>, '/c', $command)
-                     !! nqp::list('/bin/sh', '-c', $command);
+$args := $is-windows ?? nqp::list(nqp::getenvhash()<ComSpec>, nqp::getenvhash()<ComSpec>, '/c', $command)
+                     !! nqp::list('/bin/sh', '/bin/sh', '-c', $command);
 my $task := nqp::spawnprocasync($queue, $args, nqp::cwd(), nqp::getenvhash(), $config);
 nqp::permit($task, 1, -1);
 nqp::permit($task, 2, -1);
@@ -94,8 +94,8 @@ $called_ready := 0;
 # define the task
 $string  := "expected output from stderr";
 $command := "echo $string >&2";
-$args := $is-windows ?? nqp::list(nqp::getenvhash()<ComSpec>, '/c', $command)
-                     !! nqp::list('/bin/sh', '-c', $command);
+$args := $is-windows ?? nqp::list(nqp::getenvhash()<ComSpec>, nqp::getenvhash()<ComSpec>, '/c', $command)
+                     !! nqp::list('/bin/sh', '/bin/sh', '-c', $command);
 $task := nqp::spawnprocasync($queue, $args, nqp::cwd(), nqp::getenvhash(), $config);
 nqp::permit($task, 1, -1);
 nqp::permit($task, 2, -1);


### PR DESCRIPTION
The op now takes the program name separately instead of implicitly deriving
it from the first arg.