### PR TITLE
Stub some Archetypes methods expected by Rakudo

### DIFF
--- a/src/how/Archetypes.nqp
+++ b/src/how/Archetypes.nqp
@@ -21,7 +21,7 @@ my knowhow Archetypes {
     # Can this be composed (either with flattening composition, or used
     # as a mixin)?
     has $!composable;
-    
+
     # If it's not composable, does it know how to produce something
     # that is?
     has $!composalizable;

--- a/src/how/Archetypes.nqp
+++ b/src/how/Archetypes.nqp
@@ -62,4 +62,7 @@ my knowhow Archetypes {
     method composalizable() { nqp::ifnull($!composalizable, 0) }
     method generic() { nqp::ifnull($!generic, 0) }
     method parametric() { nqp::ifnull($!parametric, 0) }
+    method coercive() { 0 }
+    method definite() { 0 }
+    method augmentable() { 0 }
 }


### PR DESCRIPTION
Exceptions can come about from these being missing at times. No need for attributes; we don't have these luxuries here.

Edit: this is premature. Need a minute to test more.