### PR TITLE
Give NQPParametricRoleHOW a role_typecheck_list method

### DIFF
--- a/src/how/NQPParametricRoleHOW.nqp
+++ b/src/how/NQPParametricRoleHOW.nqp
@@ -19,6 +19,7 @@ knowhow NQPParametricRoleHOW {
 
     # Other roles that this one does.
     has @!roles;
+    has @!role_typecheck_list;
 
     # Have we been composed?
     has $!composed;
@@ -105,6 +106,14 @@ knowhow NQPParametricRoleHOW {
 
     # Compose the role. Beyond this point, no changes are allowed.
     method compose($obj) {
+        @!role_typecheck_list := my @rtl;
+        for @!roles {
+            @rtl.push: $_;
+            for $_.HOW.role_typecheck_list($_) {
+                @rtl.push: $_;
+            }
+        }
+
         $!composed := 1;
         nqp::settypecache($obj, [$obj.WHAT]);
         nqp::setmethcache($obj, {});
@@ -205,5 +214,9 @@ knowhow NQPParametricRoleHOW {
 
     method roles($obj, :$transitive = 0) {
         @!roles
+    }
+
+    method role_typecheck_list($obj) {
+        @!role_typecheck_list
     }
 }

--- a/src/how/NQPParametricRoleHOW.nqp
+++ b/src/how/NQPParametricRoleHOW.nqp
@@ -54,6 +54,7 @@ knowhow NQPParametricRoleHOW {
         @!method_order := nqp::list();
         @!multi_methods_to_incorporate := nqp::list();
         @!roles := nqp::list();
+        @!role_typecheck_list := nqp::list();
         $!composed := 0;
         $!specialize_lock := $specialize_lock;
     }
@@ -106,11 +107,10 @@ knowhow NQPParametricRoleHOW {
 
     # Compose the role. Beyond this point, no changes are allowed.
     method compose($obj) {
-        @!role_typecheck_list := my @rtl;
         for @!roles {
-            @rtl.push: $_;
+            nqp::push(@!role_typecheck_list, $_);
             for $_.HOW.role_typecheck_list($_) {
-                @rtl.push: $_;
+                nqp::push(@!role_typecheck_list, $_);
             }
         }
 

--- a/t/nqp/056-role.t
+++ b/t/nqp/056-role.t
@@ -1,4 +1,4 @@
-plan(16);
+plan(18);
 
 role R1 {
     has $!a;
@@ -56,3 +56,10 @@ role PackageUsingRole {
 class X does PackageUsingRole {
 }
 is(X.name(), 'PackageUsingRole', 'using $?PACKAGE from a role');
+
+role Bar does Foo { }
+role Baz does Bar { }
+
+my @roles := Baz.HOW.role_typecheck_list(Baz);
+ok(nqp::eqaddr(@roles[0], Bar), 'role typecheck list includes roles done');
+ok(nqp::eqaddr(@roles[1], Foo), 'role typecheck list includes roles done by roles done');


### PR DESCRIPTION
This allows Raku parametric roles to do nqp ones (e.g. weird HOWs).