### PR TITLE
Use faster `while nqp::elems(@)` vs `while @`

### DIFF
--- a/src/HLL/Actions.nqp
+++ b/src/HLL/Actions.nqp
@@ -200,7 +200,7 @@ class HLL::Actions {
         }
         if $lastlit gt '' { @parts.push(QAST::SVal.new( :value($lastlit) )); }
         my $ast := @parts ?? @parts.shift !! QAST::SVal.new( :value('') );
-        while @parts {
+        while nqp::elems(@parts) {
             $ast := QAST::Op.new( $ast, @parts.shift, :op('concat') );
         }
         make $ast;

--- a/src/HLL/Grammar.nqp
+++ b/src/HLL/Grammar.nqp
@@ -567,7 +567,7 @@ An operator precedence parser.
         elsif $opassoc eq 'list' {
             $sym := nqp::ifnull(nqp::atkey(%opOPER, 'sym'), '');
             nqp::unshift($op, nqp::pop(@termstack));
-            while @opstack {
+            while nqp::elems(@opstack) {
                 last if $sym ne nqp::ifnull(
                     nqp::atkey(nqp::atkey(nqp::atpos(@opstack,
                         nqp::elems(@opstack) - 1), 'OPER'), 'sym'), '');

--- a/src/QRegex/P5Regex/Actions.nqp
+++ b/src/QRegex/P5Regex/Actions.nqp
@@ -457,7 +457,7 @@ class QRegex::P5Regex::Actions is HLL::Actions {
         elsif $qast.rxtype eq 'concat' {
             my @tmp;
             while nqp::elems(@($qast)) { @tmp.push(@($qast).shift) }
-            while @tmp { @($qast).push(self.flip_ast(@tmp.pop)) }
+            while nqp::elems(@tmp)     { @($qast).push(self.flip_ast(@tmp.pop)) }
         }
         else {
             for @($qast) { self.flip_ast($_) }

--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -1016,7 +1016,7 @@ class QRegex::P6Regex::Actions is HLL::Actions {
         elsif $qast.rxtype eq 'concat' {
             my @tmp;
             while nqp::elems(@($qast)) { @tmp.push(@($qast).shift) }
-            while @tmp { @($qast).push(self.flip_ast(@tmp.pop)) }
+            while nqp::elems(@tmp)     { @($qast).push(self.flip_ast(@tmp.pop)) }
         }
         elsif $qast.rxtype eq 'anchor' {
             if $qast.subtype eq 'rwb' {


### PR DESCRIPTION
These lists probably aren't very long, but might as well use the more
efficient form.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.