### PR TITLE
Optimize truth checks of arrays in whiles and ifs

### DIFF
--- a/src/NQP/Optimizer.nqp
+++ b/src/NQP/Optimizer.nqp
@@ -246,6 +246,23 @@ class NQP::Optimizer {
                 $op[1].blocktype($orig);
             }
         }
+        elsif $opname eq 'while' {
+            my $conditions := $op[0];
+            if nqp::istype($conditions, QAST::Var) && nqp::substr($conditions.name, 0, 1) eq '@' {
+                $op[0] := QAST::Op.new( :op('elems'), $conditions );
+            }
+            self.visit_children($op);
+        }
+        elsif $opname eq 'if' && ($op.name eq '&infix:<&&>' || $op.name eq '&infix:<||>') {
+            my int $i := 0;
+            for @($op) -> $item {
+                if nqp::istype($item, QAST::Var) && nqp::substr($item.name, 0, 1) eq '@' {
+                    $op[$i] := QAST::Op.new( :op('elems'), $item );
+                }
+                $i++;
+            }
+            self.visit_children($op);
+        }
         else {
             self.visit_children($op);
         }


### PR DESCRIPTION
E.g., `while @a { ... }` and `if @a { ... }` are now converted into
`while nqp::elems(@a) { ... }` and `if nqp::elems(@a) { ... }`.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.

This micro benchmark:
```raku
my @a;
my int $i := 0;
while $i++ < 10_000_000 {
	nqp::push(@a, $i);
}
my $b;
my num $s := nqp::time_n;
$b := nqp::shift(@a) while @a;
say(nqp::sub_n(nqp::time_n, $s));
say($b)
```
used to take 0.08s, now it takes 0.04s.