### PR TITLE
Eliminate the ops sec_n, asec_n and sech_h, which are no longer used.

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -489,14 +489,11 @@ The opcodes are grouped into the following categories:
 ## [Trigonometric](#trig)
 
 [acos](#acos) |
-[asec](#asec) |
 [asin](#asin) |
 [atan](#atan) |
 [atan2](#atan2) |
 [cos](#cos) |
 [cosh](#cosh) |
-[sec](#sec) |
-[sech](#sech) |
 [sin](#sin) |
 [sinh](#sinh) |
 [tan](#tan) |
@@ -3276,11 +3273,6 @@ an integral number of seconds, `_n` returns a fractional amount.
 
 Arccosine.
 
-## asec
-* `asec_n(num $n --> num)`
-
-Arcsecant.
-
 ## asin
 * `asin_n(num $n --> num)`
 
@@ -3305,16 +3297,6 @@ Cosine.
 * `cosh_n(num $n --> num))`
 
 Hyperbolic cosine.
-
-## sec
-* `sec_n(num $n --> num))`
-
-Secant.
-
-## sech
-* `sech_n(num $n --> num))`
-
-Hyperbolic secant.
 
 ## sin
 * `sin_n(num $n --> num))`

--- a/src/vm/js/Operations.nqp
+++ b/src/vm/js/Operations.nqp
@@ -1014,10 +1014,6 @@ class QAST::OperationsJS {
 
     add_simple_op('atan2_n', $T_NUM, [$T_NUM, $T_NUM], sub ($y, $x) {"Math.atan2($y, $x)"});
 
-    add_simple_op('sec_n', $T_NUM, [$T_NUM]);
-    add_simple_op('asec_n', $T_NUM, [$T_NUM]);
-    add_simple_op('sech_n', $T_NUM, [$T_NUM]);
-
     add_simple_op('abs_i', $T_INT, [$T_INT], sub ($arg) {"Math.abs($arg)"});
     add_simple_op('pow_n', $T_NUM, [$T_NUM, $T_NUM]);
 

--- a/src/vm/js/nqp-runtime/core.js
+++ b/src/vm/js/nqp-runtime/core.js
@@ -1470,19 +1470,6 @@ op.mod_n = function(a, b) {
   return a - Math.floor(a / b) * b;
 };
 
-op.sec_n = function(x) {
-  return 1 / Math.cos(x);
-};
-
-op.asec_n = function(x) {
-  return Math.acos(1 / x);
-};
-
-op.sech_n = function(x) {
-  if (x == Infinity || x == -Infinity) return 0;
-  return (2 * Math.cosh(x)) / (Math.cosh(2 * x) + 1);
-};
-
 op.isnanorinf = function(n) {
   return (isNaN(n) || n == Infinity || n == -Infinity) ? 1 : 0;
 };

--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2275,9 +2275,6 @@ QAST::OperationsJAST.map_classlib_core_op('atan2_n', $TYPE_MATH, 'atan2', [$RT_N
 QAST::OperationsJAST.map_classlib_core_op('sinh_n', $TYPE_MATH, 'sinh', [$RT_NUM], $RT_NUM);
 QAST::OperationsJAST.map_classlib_core_op('cosh_n', $TYPE_MATH, 'cosh', [$RT_NUM], $RT_NUM);
 QAST::OperationsJAST.map_classlib_core_op('tanh_n', $TYPE_MATH, 'tanh', [$RT_NUM], $RT_NUM);
-QAST::OperationsJAST.map_classlib_core_op('sec_n', $TYPE_OPS, 'sec_n', [$RT_NUM], $RT_NUM);
-QAST::OperationsJAST.map_classlib_core_op('asec_n', $TYPE_OPS, 'asec_n', [$RT_NUM], $RT_NUM);
-QAST::OperationsJAST.map_classlib_core_op('sech_n', $TYPE_OPS, 'sech_n', [$RT_NUM], $RT_NUM);
 
 # esoteric math opcodes
 QAST::OperationsJAST.map_classlib_core_op('gcd_i', $TYPE_OPS, 'gcd_i', [$RT_INT, $RT_INT], $RT_INT);

--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
@@ -3723,18 +3723,6 @@ public final class Ops {
     }
 
     /* Math operations. */
-    public static double sec_n(double val) {
-        return 1 / Math.cos(val);
-    }
-
-    public static double asec_n(double val) {
-        return Math.acos(1 / val);
-    }
-
-    public static double sech_n(double val) {
-        return 1 / Math.cosh(val);
-    }
-
     public static long gcd_i(long valA, long valB) {
         return BigInteger.valueOf(valA).gcd(BigInteger.valueOf(valB))
                 .longValue();

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -2432,13 +2432,10 @@ QAST::MASTOperations.add_core_moarop_mapping('acos_n', 'acos_n');
 QAST::MASTOperations.add_core_moarop_mapping('tan_n', 'tan_n');
 QAST::MASTOperations.add_core_moarop_mapping('atan_n', 'atan_n');
 QAST::MASTOperations.add_core_moarop_mapping('atan2_n', 'atan2_n');
-QAST::MASTOperations.add_core_moarop_mapping('sec_n', 'sec_n');
-QAST::MASTOperations.add_core_moarop_mapping('asec_n', 'asec_n');
 QAST::MASTOperations.add_core_moarop_mapping('asin_n', 'asin_n');
 QAST::MASTOperations.add_core_moarop_mapping('sinh_n', 'sinh_n');
 QAST::MASTOperations.add_core_moarop_mapping('cosh_n', 'cosh_n');
 QAST::MASTOperations.add_core_moarop_mapping('tanh_n', 'tanh_n');
-QAST::MASTOperations.add_core_moarop_mapping('sech_n', 'sech_n');
 
 # esoteric math opcodes
 QAST::MASTOperations.add_core_moarop_mapping('gcd_i', 'gcd_i');

--- a/t/nqp/083-math.t
+++ b/t/nqp/083-math.t
@@ -1,4 +1,4 @@
-plan(63);
+plan(50);
 
 # Basic tests for a bunch of mathematical functions
 
@@ -44,11 +44,6 @@ is_approx(nqp::tan_n(2.0), -2.18503986326152, "nqp::tan_n(2.0)");
 is_approx(nqp::tan_n(3.0), -0.142546543074278, "nqp::tan_n(3.0)");
 is_approx(nqp::tan_n(4.0), 1.15782128234958, "nqp::tan_n(4.0)");
 
-is_approx(nqp::sec_n(1.0), 1.85081571768093, "nqp::sec_n(1.0)");
-is_approx(nqp::sec_n(2.0), -2.40299796172238, "nqp::sec_n(2.0)");
-is_approx(nqp::sec_n(3.0), -1.01010866590799, "nqp::sec_n(3.0)");
-is_approx(nqp::sec_n(4.0), -1.5298856564664, "nqp::sec_n(4.0)");
-
 is_approx(nqp::atan_n(-10.0), -1.47112767430373, "nqp::atan_n(-10.0)");
 is_approx(nqp::atan_n(-3.0), -1.24904577239825, "nqp::atan_n(-3.0)");
 is_approx(nqp::atan_n(0.0), 0.0, "nqp::atan_n(0.0)");
@@ -67,11 +62,6 @@ is_approx(nqp::asin_n(0.0), 0.0, "nqp::asin_n(0.0)");
 is_approx(nqp::asin_n(0.5), 0.523598775598299, "nqp::asin_n(0.5)");
 is_approx(nqp::asin_n(1.0), 1.5707963267949, "nqp::asin_n(1.0)");
 
-is_approx(nqp::asec_n(-2.0), 2.0943951023932, "nqp::asec_n(-2.0)");
-is_approx(nqp::asec_n(-1.0), 3.14159265358979, "nqp::asec_n(-1.0)");
-is_approx(nqp::asec_n(1.0), 0.0, "nqp::asec_n(1.0)");
-is_approx(nqp::asec_n(2.0), 1.0471975511966, "nqp::asec_n(2.0)");
-
 is_approx(nqp::sinh_n(-7.0), -548.316123273246, "nqp::sinh_n(-7.0)");
 is_approx(nqp::sinh_n(-1.0), -1.1752011936438, "nqp::sinh_n(-1.0)");
 is_approx(nqp::sinh_n(0.0), 0.0, "nqp::sinh_n(0.0)");
@@ -89,12 +79,6 @@ is_approx(nqp::tanh_n(-1.0), -0.761594155955765, "nqp::tanh_n(-1.0)");
 is_approx(nqp::tanh_n(0.0), 0.0, "nqp::tanh_n(0.0)");
 is_approx(nqp::tanh_n(1.0), 0.761594155955765, "nqp::tanh_n(1.0)");
 is_approx(nqp::tanh_n(7.0), 0.999998336943945, "nqp::tanh_n(7.0)");
-
-is_approx(nqp::sech_n(-2.0), 0.26580222883408, "nqp::sech_n(-2.0)");
-is_approx(nqp::sech_n(-1.5), 0.42509603494228, "nqp::sech_n(-1.5)");
-is_approx(nqp::sech_n(0.0), 1.0, "nqp::sech_n(0.0)");
-is_approx(nqp::sech_n(1.5), 0.42509603494228, "nqp::sech_n(1.5)");
-is_approx(nqp::sech_n(2.0), 0.26580222883408, "nqp::sech_n(2.0)");
 
 is_approx(nqp::atan2_n(90.0, 15.0), 1.4056476493802699, "nqp::atan2_n(90.0, 15.0)");
 is_approx(nqp::atan2_n(15.0, 90.0), 0.16514867741462683, "nqp::atan2_n(15.0, 90.0)");


### PR DESCRIPTION
These hyperbolic functions are not provided directly by libc, so have to be
implemented in terms of functions which are. There's no mathematical
difference in expressing the same identities in the Rakudo setting (it's
going to dispatched as the same IEEE operations) but it's better to do it
once there instead of once per backend.

Rakudo stopped using these ops in the 2021.02 release; now now remove them
from NQP and MoarVM.

The JS implementation of sech this commit removes is curious - it's
different from the JVM implementation, MoarVM's C implementation, all the
other JS implementations I can find online, and the "textbook" definition:

    sech 𝑥 = 1 / cosh 𝑥

The relevant commits don't give any clues.

However, I *believe* it to be mathematically equivalent - after a lot of
head scratching and dead ends, the identities that one needs to re-arrange
from it to the canonical definition above are that cosh 2𝑥 = cosh²𝑥 + sinh²𝑥
and cosh²𝑥 = 1 + sinh²𝑥. Hence *why* - it makes two cosh calls whereas the
"obvious" formula uses only one, *and* it has to special case ±∞. I *think*
that it might produce "better" results (ie - not just 0.0) for inputs whose
output /could/ be correctly expressed as an IEEE subnormal. But that's the
only reason I can see for doing this; I can't find it described anywhere,
and it seems a lot of work for a corner case of a corner case, which isn't
even going to be mathematically rigorous. And the fact that it needs to
special case Inf to avoid evaluating 0.0/0.0 and hence returning NaN makes
me wonder if it (still) produces similar results for some very large inputs.

Really, if you care about extreme results, you should be calculating in
symbolic algebra anyway...

Of course, if I'm wrong on this, then this approach ought to be used in the
Rakudo setting (along with the explanation of why it's objectively better.)