### PR TITLE
Remove Travis badge

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -21,8 +21,6 @@ and regular expression engine for the virtual machine.
 
 =for HTML <a href="https://dev.azure.com/Raku/nqp/_build/latest?definitionId=1&branchName=master"><img src="https://dev.azure.com/Raku/nqp/_apis/build/status/Raku.nqp?branchName=master"></a>
 
-=for HTML <a href="https://travis-ci.org/raku/nqp"><img src="https://travis-ci.org/raku/nqp.svg?branch=master"></a>
-
 To build NQP from source, you'll just need a C<make> utility and C<Perl> 5.8 or
 newer.  To automatically obtain and build MoarVM you may also need
 a C<git> client.


### PR DESCRIPTION
Travis has been disabled since the beginning of January already.

Someone should also have a look at the GitHub configuration. I suspect, the hook for Travis is still active.

Ping @Altai-man. Do you have access to the GitHub permissions and could have a look?