### PR TITLE
[JVM] Allow nqp::backtrace with nqp:null argument

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
@@ -5893,6 +5893,12 @@ public final class Ops {
         }
     }
     public static SixModelObject backtrace(SixModelObject obj, ThreadContext tc) {
+        if (isnull(obj) == 1) {
+            obj = newexception(tc);
+            ((VMExceptionInstance)obj).origin = tc.curFrame;
+            ((VMExceptionInstance)obj).nativeTrace = (new Throwable()).getStackTrace();
+        }
+
         if (obj instanceof VMExceptionInstance) {
             SixModelObject Array = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.listType;
             SixModelObject Hash = tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.hashType;


### PR DESCRIPTION
This follows https://github.com/MoarVM/MoarVM/commit/3623701173 and
should allow to unify the code for Backtrace.new between MoarVM and
JVM backend.