### PR TITLE
[JVM] Make nqp::unbox_i on NativeCall object work

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
@@ -2633,7 +2633,7 @@ public final class Ops {
                     retval = attr_st.REPR.allocate(tc, attr_st);
                     for (Field field : retval.getClass().getDeclaredFields()) {
                         try {
-                            if (field.getType().isAssignableFrom(tc.native_j.getClass())) {
+                            if (tc.native_j == null || field.getType().isAssignableFrom(tc.native_j.getClass())) {
                                 field.set(retval, tc.native_j);
                                 break;
                             }

--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
@@ -2554,7 +2554,7 @@ public final class Ops {
             return obj.get_attribute_boxed(tc, decont(ch, tc), name, STable.NO_HINT);
         }
         catch (P6OpaqueBaseInstance.BadReferenceRuntimeException badRef) {
-            SixModelObject retval = null;
+            SixModelObject retval = createNull(tc);
             obj.get_attribute_native(tc, decont(ch, tc), name, STable.NO_HINT);
             if (tc.native_type == ThreadContext.NATIVE_INT) {
                 retval = box_i((long)tc.native_i, tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.intBoxType, tc);
@@ -2615,7 +2615,7 @@ public final class Ops {
             return obj.get_attribute_boxed(tc, decont(ch, tc), name, hint);
         }
         catch (P6OpaqueBaseInstance.BadReferenceRuntimeException badRef) {
-            SixModelObject retval = null;
+            SixModelObject retval = createNull(tc);
             obj.get_attribute_native(tc, decont(ch, tc), name, hint);
             if (tc.native_type == ThreadContext.NATIVE_INT) {
                 retval = box_i((long)tc.native_i, tc.curFrame.codeRef.staticInfo.compUnit.hllConfig.intBoxType, tc);

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/NativeCallInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/NativeCallInstance.java
@@ -1,5 +1,6 @@
 package org.raku.nqp.sixmodel.reprs;
 
+import org.raku.nqp.runtime.ThreadContext;
 import org.raku.nqp.sixmodel.SixModelObject;
 
 public class NativeCallInstance extends SixModelObject {
@@ -7,4 +8,9 @@ public class NativeCallInstance extends SixModelObject {
      * P6opaque; this is about the best we can do on the JVM, which doesn't
      * support interior pointers of complex value types. */
     public NativeCallBody body;
+
+    @Override
+    public long get_int(ThreadContext tc) {
+        return body == null || body.entry_point == null ? 0 : 1;
+    }
 }


### PR DESCRIPTION
It is supposed to report whether the library was loaded or not. This
is a port of https://github.com/MoarVM/MoarVM/commit/1b0950e3e9 and
is needed since https://github.com/rakudo/rakudo/commit/9ef7a7e9dd.

nine++ gave the hint for the concrete implementation on the JVM.

Please note, that the usage of nqp::unbox_i($!call) in
lib/NativeCall.rakudmod don't work yet. They result in a
NullPointerException -- but that's probably a different bug. At least
the following code works now:

  use nqp;
  use NativeCall;
  my class native_callsite is repr('NativeCall') { };
  my $bar = native_callsite.new;
  say nqp::unbox_i($bar);  ## 0