### PR TITLE
Finish getting rid of NQPCursor

### DIFF
--- a/src/NQP/World.nqp
+++ b/src/NQP/World.nqp
@@ -632,10 +632,6 @@ class NQP::World is HLL::World {
             if nqp::existskey($result.WHO, ~$_) {
                 $result := ($result.WHO){$_};
             }
-	        # XXX temp shim to avoid bootstrapping funniness
-	        elsif nqp::elems(@name) == 1 && @name[0] eq 'NQPCursor' {
-		        return self.find_sym(['NQPMatch']);
-	        }
             else {
                 nqp::die("Could not locate compile-time value for symbol " ~
                     join('::', @name));

--- a/src/QRegex/Cursor.nqp
+++ b/src/QRegex/Cursor.nqp
@@ -1272,8 +1272,6 @@ class NQPMatch is NQPCapture does NQPMatchRole {
     }
 }
 
-my constant NQPCursor := NQPMatch;
-
 class NQPRegexMethod {
     has $!code;
     method new($code) {

--- a/t/nqp/050-regex.t
+++ b/t/nqp/050-regex.t
@@ -1,15 +1,15 @@
 plan(7);
 
-ok(NQPCursor.parse('a', :rule(/<alpha>/), :p(0)),
+ok(NQPMatch.parse('a', :rule(/<alpha>/), :p(0)),
         'Can parse "a" with <alpha> and :p(0)');
 
-ok(!NQPCursor.parse('a', :rule(/<alpha>/), :p(1)),
+ok(!NQPMatch.parse('a', :rule(/<alpha>/), :p(1)),
         'Can parse "a" with <alpha> :p(off-range)');
 
-ok(!NQPCursor.parse('a', :rule(/<alpha>/), :c(1)),
+ok(!NQPMatch.parse('a', :rule(/<alpha>/), :c(1)),
         'Can parse "a" with <alpha> :c(off-range)');
 
-ok(!NQPCursor.parse('a', :rule(/<alpha>/), :p(5)),
+ok(!NQPMatch.parse('a', :rule(/<alpha>/), :p(5)),
         'Can parse "a" with <alpha> :p(far-off-range)');
 
 ok(?('ABC' ~~ /:i abc/), ':i works with literals');

--- a/t/p5regex/01-p5regex.t
+++ b/t/p5regex/01-p5regex.t
@@ -38,7 +38,7 @@ sub test_line($line) {
     my $rxcomp := nqp::getcomp('QRegex::P5Regex');
     try {
         my $rxsub  := $rxcomp.compile($regex);
-        my $cursor := NQPCursor."!cursor_init"($target, :c(0));
+        my $cursor := NQPMatch."!cursor_init"($target, :c(0));
         my $match  := $rxsub($cursor).MATCH;
         if $expect_substr {
             my $got := ~$match."!dump_str"('mob');

--- a/t/qregex/01-qregex.t
+++ b/t/qregex/01-qregex.t
@@ -48,7 +48,7 @@ sub test_line($line) {
     my $rxcomp := nqp::getcomp('QRegex::P6Regex');
     try {
         my $rxsub  := $rxcomp.compile($regex);
-        my $cursor := NQPCursor."!cursor_init"($target, :c(0));
+        my $cursor := NQPMatch."!cursor_init"($target, :c(0));
         my $match  := $rxsub($cursor).MATCH;
 
         if $expect_error {

--- a/tools/build/process-qregex-tests
+++ b/tools/build/process-qregex-tests
@@ -8,7 +8,7 @@ sub test_line($rxsub,$target,$expect,$desc) {
                            !! "";
 
     try {
-        my $cursor := NQPCursor."!cursor_init"($target, :c(0));
+        my $cursor := NQPMatch."!cursor_init"($target, :c(0));
         my $match  := $rxsub($cursor).MATCH;
         if $expect_substr {
             my $got := ~$match."!dump_str"("mob");


### PR DESCRIPTION
Once its use is removed from the tests, the shim and constant aren't
needed anymore.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.