### PR TITLE
Remove no longer needed $!slang override in Braid

### DIFF
--- a/src/QRegex/Cursor.nqp
+++ b/src/QRegex/Cursor.nqp
@@ -267,8 +267,6 @@ role NQPMatchRole is export {
                     unless nqp::index($name,"-actions") > 0;
                 $ERR.say("  (value in braid: " ~ $bvalue.HOW.name($bvalue) ~ ", value in %*LANG: " ~ $value.HOW.name($value) ~ ")")
                     unless nqp::isnull($bvalue);
-                # XXX Override braid from %*LANG until after everyone fixes their modules.
-                nqp::bindkey(nqp::getattr($!braid, Braid, '$!slangs'), $name, $value);
             }
         }
         self


### PR DESCRIPTION
It's been long enough that modules should have been fixed by now.

Not entirely sure how to test this, but NQP builds ok and passes `make m-test`, Rakudo builds ok and passes `make m-test m-spectest`, and both Slang::SQL and Slang::Tuxic install ok and pass their (albeit quite limited) tests.