### PR TITLE
Disallow explicity specifying op write registers

### DIFF
--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -143,13 +143,9 @@ class QAST::MASTOperations {
         my @release_kinds;
 
         # if the op has operands, and the first operand is a write register,
-        # and the number of args provided is one less than the number of operands needed,
         # mark that we need to generate a result register at the end, and
         # advance to the second operand.
-        if ($num_operands
-                && (nqp::atpos_i(@operands_values, $operands_offset) +& $MVM_operand_rw_mask) == $MVM_operand_write_reg
-                    # allow the QASTree to define its own write register
-                && $num_args == $num_operands - 1) {
+        if $num_operands && (nqp::atpos_i(@operands_values, $operands_offset) +& $MVM_operand_rw_mask) == $MVM_operand_write_reg {
             $needs_write := 1;
             $operand_num++;
         }


### PR DESCRIPTION
This ability isn't used in NQP or Rakudo, and can cause confusion. E.g.,
`for nqp::split(",", "abc,def", "ghasdfi") { say($_) }` before would
print "ghasdfi", now it dies with `Arg count 3 doesn't equal required
operand count 2 for op 'split'`.

NQP builds ok and passes `make m-test` and Rakudo builds ok and passes `make m-test m-spectest`.