### PR TITLE
Revert "Lazy allocation of HashMap for  VMHash storage on JVM."

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMHash.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMHash.java
@@ -25,7 +25,7 @@ public class VMHash extends REPR {
     public SixModelObject allocate(ThreadContext tc, STable st) {
         VMHashInstance obj = new VMHashInstance();
         obj.st = st;
-        obj.storage = VMHashInstance.EMPTY_MAP;
+        obj.storage = new HashMap<String, SixModelObject>();
         return obj;
     }
 
@@ -38,7 +38,7 @@ public class VMHash extends REPR {
     public SixModelObject deserialize_stub(ThreadContext tc, STable st) {
         VMHashInstance obj = new VMHashInstance();
         obj.st = st;
-        obj.storage = VMHashInstance.EMPTY_MAP;
+        obj.storage = new HashMap<String, SixModelObject>();
         return obj;
     }
 

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMHashInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMHashInstance.java
@@ -6,9 +6,6 @@ import org.raku.nqp.runtime.ThreadContext;
 import org.raku.nqp.sixmodel.SixModelObject;
 
 public class VMHashInstance extends SixModelObject {
-    public static final HashMap<String, SixModelObject> EMPTY_MAP =
-            new HashMap<String, SixModelObject>();
-
     public HashMap<String, SixModelObject> storage;
 
     @Override
@@ -18,9 +15,6 @@ public class VMHashInstance extends SixModelObject {
 
     @Override
     public void bind_key_boxed(ThreadContext tc, String key, SixModelObject value) {
-        if (storage == VMHashInstance.EMPTY_MAP) {
-            storage = new HashMap<String, SixModelObject>();
-        }
         storage.put(key, value);
     }
 

--- a/t/serialization/01-basic.t
+++ b/t/serialization/01-basic.t
@@ -1,4 +1,4 @@
-plan(1523);
+plan(1525);
 
 {
     my $sc := nqp::createsc('exampleHandle');
@@ -605,6 +605,7 @@ sub fresh_out_sc() {
 
 # Serializing an SC with a VMArray
 {
+    my $old-empty-hash := nqp::hash();
     my $sc := nqp::createsc(fresh_in_sc());
     my $sh := nqp::list_s();
 
@@ -628,6 +629,10 @@ sub fresh_out_sc() {
     is(nqp::scgetobj($dsc, 0)<hi>, 123, 'element of hash is correct');
     is(nqp::scgetobj($dsc, 0)<hello>, 456, 'element of hash is correct');
     is(nqp::scgetobj($dsc, 0)<ciao>, 789, 'element of hash is correct');
+
+    is(nqp::elems($old-empty-hash), 0, 'other hash unaffected by deserialization');
+    my $new-empty-hash := nqp::hash();
+    is(nqp::elems($new-empty-hash), 0, 'newly created hash starts empty');
 }
 
 {


### PR DESCRIPTION
This reverts commit f7c396af6b3bf6f3260c4d8c7507284a86ca53dc.

It turned out that we had at least one place where we didn't check if
the storage of a VMHash was still VMHashInstance.EMPTY_MAP:

  https://github.com/Raku/nqp/blob/f1469fad3d/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMHash.java#L53

Since VMHashInstance.EMPTY_MAP was shared between different instances
of VMHash, putting key/value pairs into storage affected all VMHashes
that didn't get their dedicated storage, yet.

If I'm not mistaken this was the underlying reason for

  my constant $foo = nqp::hash();

not working correctly in the setting on the JVM backend. It also
explains strange problems with %DEPRECATIONS suddenly (after calling
nqp::deserialize) containing key/value pairs from other objects -- as
decribed in https://github.com/rakudo/rakudo/issues/3158.

Now for the actual fix: An alternative would have been to add a check
for VMHashInstance.EMPTY_MAP in deserialize_finish (see link above).
But since storage is a public field of each VMHashInstance, IMHO this
would be error prone, since each user would have to know about
VMHashInstance.EMPTY_MAP and check for it. So I didn't went that road.

Conflicts solved in:
    src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMHashInstance.java