### PR TITLE
Fix sprintf large int tests

### DIFF
--- a/t/hll/06-sprintf.t
+++ b/t/hll/06-sprintf.t
@@ -51,7 +51,8 @@ my class SprintfHandler {
 my $knowhow := nqp::knowhow().new_type(:name('TestBigInt'), :repr("P6bigint"));
 nqp::sprintfaddargumenthandler(SprintfHandler.new);
 my $large-positive-int := nqp::pow_I(nqp::box_i(33, $knowhow), nqp::box_i(21, $knowhow), $knowhow, $knowhow);
-my $large-negative-int := nqp::fromnum_I(nqp::neg_n(nqp::pow_n(2.42, 42.0)), $knowhow);
+my $large-negative-int := nqp::pow_I(nqp::box_i(24, $knowhow), nqp::box_i(17, $knowhow), $knowhow, $knowhow);
+$large-negative-int := nqp::neg_I($large-negative-int, $knowhow);
 
 
 is(nqp::sprintf('<%6s>', [12]), '<    12>', 'right-justified %s with space padding');
@@ -83,7 +84,7 @@ is(nqp::sprintf('<%04d>', [-1]), '<-001>', '%d on negative decimal with 0-paddin
 is(nqp::sprintf('<%+4d>', [42]), '< +42>', '%d on a positive decimal, space-padding with plus sign');
 is(nqp::sprintf('<%+04d>', [42]), '<+042>', '%d on a positive decimal, zero-padding with plus sign');
 is(nqp::sprintf('<%d>', [$large-positive-int]), '<77409228207421416473589288028833>', '%d on bigint');
-is(nqp::sprintf('<%d>', [$large-negative-int]), '<-13190017482579452>', '%d on negative bigint');
+is(nqp::sprintf('<%d>', [$large-negative-int]), '<-290797794982682557415424>', '%d on negative bigint');
 
 is(nqp::sprintf('%c', [97]), 'a', '%c directive');
 is(nqp::sprintf('%10c', [65]), '         A', '%c directive with space padding');


### PR DESCRIPTION
By setting up the ints to print more robust.
See https://github.com/MoarVM/MoarVM/pull/1385#issuecomment-748591561 for the analysis that lead up to this.