### PR TITLE
[JVM] Deserialize native arrays as such

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/REPRRegistry.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/REPRRegistry.java
@@ -73,6 +73,15 @@ public class REPRRegistry {
         addREPR("P6opaque", new P6Opaque());
         addREPR("VMHash", new VMHash());
         addREPR("VMArray", new VMArray());
+        addREPR("VMArray_i8", new VMArray());
+        addREPR("VMArray_u8", new VMArray());
+        addREPR("VMArray_i16", new VMArray());
+        addREPR("VMArray_u16", new VMArray());
+        addREPR("VMArray_i32", new VMArray());
+        addREPR("VMArray_u32", new VMArray());
+        addREPR("VMArray_i", new VMArray());
+        addREPR("VMArray_n", new VMArray());
+        addREPR("VMArray_s", new VMArray());
         addREPR("VMIter", new VMIter());
         addREPR("P6str", new P6str());
         addREPR("P6int", new P6int());

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMArray.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMArray.java
@@ -88,7 +88,43 @@ public class VMArray extends REPR {
     public SixModelObject deserialize_stub(ThreadContext tc, STable st) {
         SixModelObject obj;
         if (st.REPRData == null) {
-            obj = new VMArrayInstance();
+            // Either a real VMArray or REPRData not yet known.
+            switch (st.REPR.name) {
+            case "VMArray":
+                obj = new VMArrayInstance();
+                break;
+            case "VMArray_i8":
+                obj = new VMArrayInstance_i8();
+                break;
+            case "VMArray_u8":
+                obj = new VMArrayInstance_u8();
+                break;
+            case "VMArray_i16":
+                obj = new VMArrayInstance_i16();
+                break;
+            case "VMArray_u16":
+                obj = new VMArrayInstance_u16();
+                break;
+            case "VMArray_i32":
+                obj = new VMArrayInstance_i32();
+                break;
+            case "VMArray_u32":
+                obj = new VMArrayInstance_u32();
+                break;
+            case "VMArray_i":
+                obj = new VMArrayInstance_i();
+                break;
+            case "VMArray_n":
+                obj = new VMArrayInstance_n();
+                break;
+            case "VMArray_s":
+                obj = new VMArrayInstance_s();
+                break;
+            default:
+                throw ExceptionHandling.dieInternal(tc, "Invalid REPR name for VMArray");
+            }
+            // Set real REPR name (we cheated during serialization).
+            st.REPR.name = "VMArray";
         }
         else {
             StorageSpec ss = ((VMArrayREPRData)st.REPRData).ss;


### PR DESCRIPTION
There is a long standing issue with Rakudo on the JVM backend:
If one declares a native array (like 'my int @arr;') this comes
out as a non-native array after precompilation.
(Compare https://github.com/rakudo/rakudo/issues/1666.)

I think I figured out what happened: Both, native and non-native
arrays have the REPR 'VMArray'. They differ in native arrays having
a non-null REPRData in their STable. When an array is serialized, a
string representing the REPR is put into the string heap. During the
first pass of deserialization, this string is used to create a stub
object (of the given REPR). At this moment the REPRData is not yet
known -- so a plain (non-native) VMArray is created. Only during the
second pass of deserialization, the REPRData is added to the STable
(in deserialize_repr_data). But that's too late to change the object.

My patch tweaks the string that is put into the string heap, so that
the correct stub object can be created. If I'm not mistaken, this fake
REPR name isn't used in another place and it is corrected during the
first pass of deserialization. This doesn't feel clean, but it seems
to work.