### PR TITLE
[JVM] Keep different REPR.name for native arrays

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMArray.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMArray.java
@@ -123,8 +123,6 @@ public class VMArray extends REPR {
             default:
                 throw ExceptionHandling.dieInternal(tc, "Invalid REPR name for VMArray");
             }
-            // Set real REPR name (we cheated during serialization).
-            st.REPR.name = "VMArray";
         }
         else {
             StorageSpec ss = ((VMArrayREPRData)st.REPRData).ss;


### PR DESCRIPTION
It turned out that f3dc977906 doesn't really fix the usage of native
arrays in the core setting. For some reason during the compilation of
blib/CORE.d.setting.jar native array are deserialized twice.

The first time worked as expected, but since we did reset REPR.name
to VMArray, the second time went wrong just as it used to faile before
f3dc977906.

Since REPR.name is only used for serialization/deserialization and for
error reporting in two base classes, it seems to be acceptable to just
keep the suffixes (VMArray_i, VMArray_u32, etc.).