### PR TITLE
[JVM] Keep correct REPR.name for native arrays

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/REPR.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/REPR.java
@@ -22,6 +22,12 @@ public abstract class REPR {
     public String name;
 
     /**
+     * Name that is used to differentiate between native and non-native
+     * VMArrays during deserialization. Not used for other representations.
+     */
+    public String vmarray_name;
+
+    /**
      * Creates a new type object of this representation, and associates it
      * with the given HOW.
      */

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/REPR.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/REPR.java
@@ -22,10 +22,12 @@ public abstract class REPR {
     public String name;
 
     /**
-     * Name that is used to differentiate between native and non-native
-     * VMArrays during deserialization. Not used for other representations.
+     * A name that is used to differentiate between different (sub)types that
+     * have the same representation otherwise.
+     * Can be left unset for most representations, but is used to detect
+     * native VMArrays during deserialization.
      */
-    public String vmarray_name;
+    public String subtype_name;
 
     /**
      * Creates a new type object of this representation, and associates it

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/REPRRegistry.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/REPRRegistry.java
@@ -64,12 +64,11 @@ public class REPRRegistry {
         REPR.ID = reprs.size();
         reprIdMap.put(name, reprs.size());
         if (name.startsWith("VMArray")) {
-            /* To detect native VMArrays during deserialization we set an extra
-             * field. This isn't used for other representations.
-             * We can set the correct name (VMArray) at this point, since
+            /* To detect native VMArrays during deserialization we use an extra
+             * field. We can set the correct name (VMArray) at this point, since
              * lookup will be done from reprIdMap, which knows the long name.
              */
-            REPR.vmarray_name = name;
+            REPR.subtype_name = name;
             name = "VMArray";
         }
         REPR.name = name;

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/REPRRegistry.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/REPRRegistry.java
@@ -62,8 +62,17 @@ public class REPRRegistry {
 
     private static void addREPR(String name, REPR REPR) {
         REPR.ID = reprs.size();
-        REPR.name = name;
         reprIdMap.put(name, reprs.size());
+        if (name.startsWith("VMArray")) {
+            /* To detect native VMArrays during deserialization we set an extra
+             * field. This isn't used for other representations.
+             * We can set the correct name (VMArray) at this point, since
+             * lookup will be done from reprIdMap, which knows the long name.
+             */
+            REPR.vmarray_name = name;
+            name = "VMArray";
+        }
+        REPR.name = name;
         reprs.add(REPR);
     }
 

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/SerializationWriter.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/SerializationWriter.java
@@ -550,11 +550,11 @@ public class SerializationWriter {
         growToHold(STABLES, STABLES_TABLE_ENTRY_SIZE);
 
         /* Make STables table entry. */
+        String reprNameForSerialization = st.REPR.name;
         if (st.REPRData instanceof VMArrayREPRData) {
             /* Workaround for native arrays. If they end up as VMArray in the
              * string heap, a plain VMArray will be created in deserialize_stub.
              * So we cheat and add a suffix to the real REPR name. */
-            String reprNameForSerialization;
             StorageSpec ss = ((VMArrayREPRData)st.REPRData).ss;
             switch (ss.boxed_primitive) {
             case StorageSpec.BP_INT:
@@ -584,11 +584,8 @@ public class SerializationWriter {
             default:
                 throw ExceptionHandling.dieInternal(tc, "Invalid REPR data for VMArray");
             }
-            outputs[STABLES].putInt(addStringToHeap(reprNameForSerialization));
         }
-        else {
-            outputs[STABLES].putInt(addStringToHeap(st.REPR.name));
-        }
+        outputs[STABLES].putInt(addStringToHeap(reprNameForSerialization));
         outputs[STABLES].putInt(outputs[STABLE_DATA].position());
 
         /* Make sure we're going to write to the correct place. */

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMArray.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMArray.java
@@ -89,7 +89,7 @@ public class VMArray extends REPR {
         SixModelObject obj;
         if (st.REPRData == null) {
             // Either a real VMArray or REPRData not yet known.
-            switch (st.REPR.vmarray_name) {
+            switch (st.REPR.subtype_name) {
             case "VMArray":
                 obj = new VMArrayInstance();
                 break;

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMArray.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMArray.java
@@ -89,7 +89,7 @@ public class VMArray extends REPR {
         SixModelObject obj;
         if (st.REPRData == null) {
             // Either a real VMArray or REPRData not yet known.
-            switch (st.REPR.name) {
+            switch (st.REPR.vmarray_name) {
             case "VMArray":
                 obj = new VMArrayInstance();
                 break;
@@ -123,8 +123,6 @@ public class VMArray extends REPR {
             default:
                 throw ExceptionHandling.dieInternal(tc, "Invalid REPR name for VMArray");
             }
-            // Set real REPR name (we cheated during serialization).
-            st.REPR.name = "VMArray";
         }
         else {
             StorageSpec ss = ((VMArrayREPRData)st.REPRData).ss;


### PR DESCRIPTION
It turned out that f3dc977 doesn't really fix the usage of native
arrays in the core setting. For some reason during the compilation of
blib/CORE.d.setting.jar native array are deserialized twice.

The first time worked as expected, but since we did reset REPR.name
to VMArray, the second time went wrong just as it used to fail before
f3dc977.

Since REPR.name is also used for nqp::reprname, it seems cleaner to
leave it untouched and add a different field (vmarray_name) to REPR
instead.