### PR TITLE
Partially implement translate_newlines config in JVM backend's DecoderInstance

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
@@ -69,6 +69,10 @@ public class DecoderInstance extends SixModelObject {
         }
     }
 
+    public synchronized String maybe_translate_newlines(ThreadContext tc, String str) {
+        return translate_newlines ? str.replace("\r\n", "\n") : str;
+    }
+
     public synchronized String takeChars(ThreadContext tc, long chars, boolean eof) {
         ensureConfigured(tc);
 
@@ -92,6 +96,7 @@ public class DecoderInstance extends SixModelObject {
         String normalized = Normalizer.normalize(
             decodedBuffer(target),
             Normalizer.Form.NFC);
+        normalized = maybe_translate_newlines(tc, normalized);
         if (normalized.length() > chars) {
             String result = normalized.substring(0, (int)chars);
             String remaining = normalized.substring((int)chars, normalized.length());
@@ -131,6 +136,7 @@ public class DecoderInstance extends SixModelObject {
         String normalized = Normalizer.normalize(
             decodedBuffer(target),
             Normalizer.Form.NFC);
+        normalized = maybe_translate_newlines(tc, normalized);
         if (normalized.length() == 0 || isNormTerminated(normalized))
             return normalized;
         String result = normalized.substring(0, normalized.length() - 1);
@@ -160,7 +166,7 @@ public class DecoderInstance extends SixModelObject {
             decoder.reset();
         }
         String normalized = Normalizer.normalize(decodedBuffer(target), Normalizer.Form.NFC);
-        return translate_newlines ? normalized.replace("\r\n", "\n") : normalized;
+        return maybe_translate_newlines(tc, normalized);
     }
 
     public synchronized String takeLine(ThreadContext tc, boolean chomp, boolean eof) {

--- a/t/nqp/019-file-ops.t
+++ b/t/nqp/019-file-ops.t
@@ -363,7 +363,7 @@ if $is-windows {
     is($fh.readchars(2), 'π1', 'readchars the second time with a multi byte character');
     $fh.get;
     is($fh.readchars(5), 'line3', 'readchars after get');
-    is($fh.readchars(150), "line4\n", 'readchars with more chars then they are in the file');
+    is($fh.readchars(150), "line4\n", 'readchars with more chars than are in the file');
     close($fh);
 }
 


### PR DESCRIPTION
Add a boolean member for it (defaults to false) and set it based on the
config hash if given.

Currently only takeAllChars uses it, because that's all that was needed
to get both t/nqp/019-file-opt.t and t/nqp/116-streaming-decoder.t to
pass on Windows with the JVM backend.

This will allow us to turn back on the JVM-on-Windows NQP test job in CI, which I accidentally did in #719, so after a rebase that PR should all pass.