### PR TITLE
Simplify MoarVM backend runner's Makefile template

### DIFF
--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -25,9 +25,6 @@
   @moar::ccinc@@nfpq(@moar::prefix@/include/moar)@ \
   @moar::ccinc@@nfpq(@moar::prefix@/include/libatomic_ops)@ \
   @moar::ccinc@@nfpq(@moar::prefix@/include/dyncall)@ \
-  @moar::ccinc@@nfpq(@moar::prefix@/include/moar)@ \
-  @moar::ccinc@@nfpq(@moar::prefix@/include/sha1)@ \
-  @moar::ccinc@@nfpq(@moar::prefix@/include/tinymt)@ \
   @moar::ccinc@@nfpq(@moar::prefix@/include/libtommath)@ \
   @moar::ccinc@@nfpq(@moar::prefix@/include/libuv)@
 


### PR DESCRIPTION
Remove one redundant entry ('moar') and two unneeded entries ('sha1',
'tinymt').