### PR TITLE
Remove no longer needed JVM workaround

### DIFF
--- a/src/HLL/SysConfig.nqp
+++ b/src/HLL/SysConfig.nqp
@@ -14,13 +14,7 @@ class HLL::SysConfig {
         $!path-sep := nqp::backendconfig<osname> eq 'MSWin32' ?? '\\' !! '/';
 
         # Determine NQP home
-#?if jvm
-        # TODO could be replaced by nqp::execname() after the next bootstrap for JVM
-        my $execname := nqp::atkey(nqp::jvmgetproperties,'nqp.execname') // '';
-#?endif
-#?if !jvm
         my $execname := nqp::execname;
-#?endif
         my $install-dir := $execname eq ''
             ?? %!build-config<prefix>
             !! nqp::substr($execname, 0, nqp::rindex($execname, $!path-sep, nqp::rindex($execname, $!path-sep) - 1));


### PR DESCRIPTION
The JVM has been re-bootstrapped and `nqp::execname` now works with it.