### PR TITLE
Implement support for moar::hllincludes config variable

### DIFF
--- a/tools/templates/Makefile-backend-common.in
+++ b/tools/templates/Makefile-backend-common.in
@@ -188,4 +188,4 @@
 @backend_prefix@-qregex-test-loud: @bpm(BUILD_RUNNER)@
 	$(PROVE) -r -v --exec @nfpq(@bpm(BUILD_RUNNER)@)@ @nfp(t/qregex)@
 
-# vim: ft=make tw=4 sw=4 noexpandtab
+# vim: ft=make ts=4 sw=4 noexpandtab

--- a/tools/templates/moar/Makefile.in
+++ b/tools/templates/moar/Makefile.in
@@ -20,13 +20,7 @@
   @bpm(INST_NQP)@
 
 @bpv(MOAR_INC_PATHS)@ = \
-  @moar::cincludes@ \
-  @moar::ccinc@@nfpq(@moar::prefix@/include)@ \
-  @moar::ccinc@@nfpq(@moar::prefix@/include/moar)@ \
-  @moar::ccinc@@nfpq(@moar::prefix@/include/libatomic_ops)@ \
-  @moar::ccinc@@nfpq(@moar::prefix@/include/dyncall)@ \
-  @moar::ccinc@@nfpq(@moar::prefix@/include/libtommath)@ \
-  @moar::ccinc@@nfpq(@moar::prefix@/include/libuv)@
+    @insert_list(moar_includes)@
 
 @for_stages(@bpv(@ucstage@_GEN_CAT)@ = @bpm(GEN_CAT)@ @lcstage@
 )@

--- a/tools/templates/moar/moar_includes
+++ b/tools/templates/moar/moar_includes
@@ -1,0 +1,5 @@
+@moar::cincludes@
+@moar::ccinc@@nfpq(@moar::prefix@/include)@
+@for(moar::hllincludes
+@moar::ccinc@@nfpq(@moar::prefix@/include/@_@)@
+)@


### PR DESCRIPTION
List of include directories is now provided by moar backend and respected by NQP build.