### PR TITLE
Wrap QAST::Regex from qbuildsub in QAST::Stmts...

### DIFF
--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -7,7 +7,7 @@ class QRegex::P6Regex::Actions is HLL::Actions {
             :compilation_mode(0),
             :pre_deserialize($*W.load_dependency_tasks()),
             :post_deserialize($*W.fixup_tasks()),
-            self.qbuildsub($<nibbler>.ast, :anon(1), :addself(1))
+            self.qbuildsub($<nibbler>.ast, :node($/), :anon(1), :addself(1))
         );
     }
 
@@ -215,7 +215,7 @@ class QRegex::P6Regex::Actions is HLL::Actions {
     }
 
     method metachar:sym<( )>($/) {
-        my $sub_ast := QAST::NodeList.new(self.qbuildsub($<nibbler>.ast, :anon(1), :addself(1)));
+        my $sub_ast := QAST::NodeList.new(self.qbuildsub($<nibbler>.ast, :node($/), :anon(1), :addself(1)));
         my $ast := QAST::Regex.new( $sub_ast, $<nibbler>.ast, :rxtype('subrule'),
                                      :subtype('capture'), :node($/) );
         make $ast;
@@ -605,15 +605,15 @@ class QRegex::P6Regex::Actions is HLL::Actions {
                     my int $litlen := self.offset_ast($<nibbler>.ast);
                     if $litlen >= 0 {
                         $qast[0][0].value('before');
-                        $qast[0].push(self.qbuildsub($<nibbler>.ast, :anon(1), :addself(1)));
+                        $qast[0].push(self.qbuildsub($<nibbler>.ast, :node($/), :anon(1), :addself(1)));
                         $qast[0].push(QAST::IVal.new( :value($litlen) ));  # optional offset to before
                     }
                     else {
-                        $qast[0].push(self.qbuildsub(self.flip_ast($<nibbler>.ast), :anon(1), :addself(1)));
+                        $qast[0].push(self.qbuildsub(self.flip_ast($<nibbler>.ast), :node($/), :anon(1), :addself(1)));
                     }
                 }
                 else {
-                    $qast[0].push(self.qbuildsub($<nibbler>.ast, :anon(1), :addself(1)));
+                    $qast[0].push(self.qbuildsub($<nibbler>.ast, :node($/), :anon(1), :addself(1)));
                 }
             }
         }
@@ -831,7 +831,7 @@ class QRegex::P6Regex::Actions is HLL::Actions {
         return $qast
     }
 
-    method qbuildsub($qast, $block = QAST::Block.new(), :$anon, :$addself, *%rest) {
+    method qbuildsub($qast, $block = QAST::Block.new(), :$node, :$anon, :$addself, *%rest) {
 	my $*LANG := $qast.node;
         my $code_obj := nqp::existskey(%rest, 'code_obj')
             ?? %rest<code_obj>
@@ -879,7 +879,7 @@ class QRegex::P6Regex::Actions is HLL::Actions {
         if %*RX<r> {
             $qast[2].backtrack('r');
         }
-        $block.push($qast);
+        $block.push(QAST::Stmts.new($qast, :$node));
 
         self.set_cursor_type($qast);
 


### PR DESCRIPTION
and add a `:node` parameter to `qbuildsub()` and pass in `$/` when it's
called, this is then set as the `:node` argument to the new QAST::Stmts
call. The combination of these changes means that we now get a filename
set for more regex parts of a backtrace. E.g., `raku --ll-exception -e
'grammar G { token TOP { $<foo>=(<xxx>) } }; G.parse("x")'` now reports
'-e' instead of '\<unknown\>' for the backtrace line before the 'TOP'.

This results in one passing TODO in t/spec/S32-exceptions/misc2.t and
one new fail in t/spec/S02-lexical-conventions/comments.t (gets an
`X::Syntax::Comment::Embedded` instead of an `X::Syntax::Confused`), but
I think the new exception is a better one and roast should be changed.