### PR TITLE
[JVM] Deal with invalid input in decodertakeline

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/DecoderInstance.java
@@ -201,10 +201,13 @@ public class DecoderInstance extends SixModelObject {
             CharBuffer target = CharBuffer.allocate(decodee.limit());
 
             CoderResult result = decoder.decode(decodee, target, eof && toDecode.size() == 1);
-            /* TODO It looks like we read binary data with UTF_8 during
-             * normal operation; don't die then. */
-            if (result.isMalformed() && charset != StandardCharsets.UTF_8)
-                Ops.die_s("Will not decode invalid " + charset, tc);
+            if (result.isMalformed()) {
+                /* We encountered malformed input. But it could be that we found enough
+                 * valid input to return a whole line. So we should only die if we
+                 * didn't get anything in the output buffer. */
+                if (target.position() == 0)
+                    Ops.die_s("Will not decode invalid " + charset, tc);
+            }
 
             decoded.add(decodedBuffer(target));
             if (decodee.remaining() == 0)


### PR DESCRIPTION
As long as we have lines of correctly encoded input, decodertakeline
is supposed to return a valid line -- even if there is invalid data
(for the given encoding) later in the input. It should die only if
it reaches the invalid input on the line it wants to return.

A concrete example of this behaviour is exercised in the method
!read-dependencies in Rakudo's CompUnit::PrecompilationUnit::File:
The precomp files we handle there have some leading lines of text,
followed by an empty line and then there is binary data.
In the method we call IO::Handle.get repeatedly -- which uses
nqp::decodertakeline under the hood. The old code needed a dirty
workaround to not explode at this point. Now the situation is
handled more correctly.