### PR TITLE
Eliminate use of nqp::attrinited

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -339,7 +339,6 @@ The opcodes are grouped into the following categories:
 
 ## [Objects](#objects)
 
-[attrinited](#attrinited) |
 [bind](#bind) |
 [bindattr](#bindattr) |
 [bindcomp](#bindcomp) |
@@ -2177,13 +2176,6 @@ truncated, `nqp::srand(1)` and `nqp::srand(1.1)` are the same so always pass `nq
 an integer.
 
 # <a id="objects"></a> Objects
-
-## attrinited
-* `attrinited(Mu $obj. Mu:T $type, str $attributename --> int)`
-
-Test if the attribute of name `$attributename` of object `$obj`
-has been bound, see `bindattr`. Note that any access to the atribute
-that results in a `getattr` call causes it to be inited.
 
 ## bind
 * `bind(Mu $variable, Mu $value)`

--- a/src/core/NQPMu.nqp
+++ b/src/core/NQPMu.nqp
@@ -28,7 +28,7 @@ my class NQPMu {
                     }
                 }
                 elsif nqp::iseq_i($code, 4) {
-                    unless nqp::attrinited(self, nqp::atpos($task, 1), nqp::atpos($task, 2)) {
+                    unless nqp::eqaddr(nqp::getattr(self, nqp::atpos($task, 1), nqp::atpos($task, 2)), NQPMu) {
                         nqp::bindattr(self, nqp::atpos($task, 1), nqp::atpos($task, 2),
                             nqp::atpos($task, 3)(self,
                                 nqp::getattr(self, nqp::atpos($task, 1), nqp::atpos($task, 2))));

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -3387,7 +3387,6 @@ while $i < $n {
 
 QAST::MASTOperations.add_core_moarop_mapping('rebless', 'rebless', :decont(0, 1));
 QAST::MASTOperations.add_core_moarop_mapping('istype', 'istype', :decont(0, 1));
-QAST::MASTOperations.add_core_moarop_mapping('attrinited', 'attrinited', :decont(1));
 QAST::MASTOperations.add_core_moarop_mapping('setboolspec', 'setboolspec', 0, :decont(0));
 QAST::MASTOperations.add_core_moarop_mapping('settypecache', 'settypecache', 0, :decont(0));
 QAST::MASTOperations.add_core_moarop_mapping('settypecheckmode', 'settypecheckmode', 0, :decont(0));

--- a/t/nqp/058-attrs.t
+++ b/t/nqp/058-attrs.t
@@ -1,4 +1,4 @@
-plan(35);
+plan(30);
 
 class Foo {
     has $!answer;
@@ -114,38 +114,6 @@ class ClassB {
 }
 ok(nqp::ishash(ClassA.new.get_attr), 'BUILD initializes a % attribute with a hash');
 ok(nqp::isnull(ClassB.new.get_attr), 'without a BUILD a % attribute is initialized with a null');
-
-class AttrInitedTest {
-    has $!attr1;
-    has $!attr2;
-    method get_attr1() {
-        $!attr1;
-    }
-    method set_attr2() {
-        $!attr2 := 200
-    }
-    has int $!attr3;
-    method set_attr3() {
-        $!attr3 := 200
-    }
-
-    has int $!attr4;
-    method get_attr4() {
-        $!attr1;
-    }
-}
-my $partial := AttrInitedTest.new;
-ok(!nqp::attrinited($partial, AttrInitedTest, '$!attr1'), 'nqp::attrinitied on a uninitialized attr');
-$partial.get_attr1;
-ok(nqp::attrinited($partial, AttrInitedTest, '$!attr1'), 'nqp::attrinitied on a attr that has been autovivified');
-$partial.set_attr2;
-ok(nqp::attrinited($partial, AttrInitedTest, '$!attr2'), 'nqp::attrinitied on a attr that has been bound to');
-
-my $in_void := AttrInitedTest.new;
-ok(!nqp::attrinited($in_void, AttrInitedTest, '$!attr1'), 'nqp::attrinitied before getting attr');
-nqp::getattr($in_void, AttrInitedTest, '$!attr1');
-ok(nqp::attrinited($in_void, AttrInitedTest, '$!attr1'), 'nqp::attrinitied with nqp::getattr as void');
-
 
 use nqpmo;
 

--- a/t/serialization/01-basic.t
+++ b/t/serialization/01-basic.t
@@ -1,4 +1,4 @@
-plan(1518);
+plan(1514);
 
 {
     my $sc := nqp::createsc('exampleHandle');
@@ -492,51 +492,6 @@ sub fresh_out_sc() {
     my $matching := nqp::nfarunproto($deserialized_nfa,"foo",0);
     ok(nqp::elems($matching) == 1,"we can match a simple string using the deserialized NFA");
     ok(nqp::atpos_i($matching, 0) == 11,"...and we get the right fate");
-}
-
-# nqp::attrinitied works after serialization
-{
-    my $sc := nqp::createsc(fresh_in_sc());
-    my $sh := nqp::list_s();
-
-    my class TestAttrinitied {
-        has $!written;
-        has $!read;
-        has $!not_inited;
-        has $!null;
-        method write() {
-            $!written := 123;
-            $!null := nqp::null();
-        }
-        method read() {
-            if $!read {
-                ok(0);
-            }
-        }
-    }
-
-    my $v := TestAttrinitied.new();
-    $v.write();
-    $v.read();
-
-    add_to_sc($sc, 0, $v);
-
-    my $serialized := nqp::serialize($sc, $sh);
-
-    my $dsc := nqp::createsc(fresh_out_sc());
-    nqp::deserialize($serialized, $dsc, $sh, nqp::list(), nqp::null());
-
-    ok(nqp::attrinited(nqp::scgetobj($dsc, 0), TestAttrinitied, '$!written'), 'nqp::attrinited on an attribute that has been written to');
-    ok(!nqp::attrinited(nqp::scgetobj($dsc, 0), TestAttrinitied, '$!not_inited'), 'nqp::attinitied on an attribute that has not be initialized');
-    ok(nqp::attrinited(nqp::scgetobj($dsc, 0), TestAttrinitied, '$!read'), 'nqp::attrinited on an attribute that has been autovivified');
-
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('null handling is broken on the jvm', 1);
-    }
-    else {
-        ok(nqp::attrinited(nqp::scgetobj($dsc, 0), TestAttrinitied, '$!null'), 'nqp::attrinited on an attribute that has been set with null');
-    }
-
 }
 
 # Serializing an SC with a VMArray


### PR DESCRIPTION
This is a follow-up to https://github.com/rakudo/rakudo/pull/4633 that also removes the use of `nqp::attrinited` in NQP; it cannot be merged until the Rakudo PR has been merged. This does not do a rebootstrap, which would be the final step needed before MoarVM can drop support, as further changes to object representation configuration are also planned.