### PR TITLE
[JVM] Fix conversion to unsigned int

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/MultiDimArrayInstance_u32.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/MultiDimArrayInstance_u32.java
@@ -9,7 +9,7 @@ public class MultiDimArrayInstance_u32 extends MultiDimArrayInstanceBase {
     public int[] slots;
 
     private static long widen(int i) {
-        return i < 0 ? i + (1 << 32) : i;
+        return i < 0 ? i + (1L << 32) : i;
     }
 
     @Override

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMArrayInstance_u32.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/VMArrayInstance_u32.java
@@ -12,7 +12,7 @@ public class VMArrayInstance_u32 extends VMArrayInstanceBase {
     public int[] slots;
 
     private static long widen(int i) {
-        return i < 0 ? i + (1 << 32) : i;
+        return i < 0 ? i + (1L << 32) : i;
     }
 
     @Override


### PR DESCRIPTION
... in VMArray with 32 bit. The old code handled the 1 as a signed
integer, so that (1 << 32) just evaluated to 1.

An alternative would have been to use Integer.toUnsignedLong(i),
which is available since Java 8. We could change to those methods
in the future -- but for consistency the should be used for the
other types of VMArrays as well.