### PR TITLE
Implement the -o form of the --output option

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -311,7 +311,7 @@ class HLL::Compiler does HLL::Backend::Default {
                     $!user_progname := '-e';
                     my $?FILES := '-e';
                     $result := self.eval(%adverbs<e>, '-e', |@a, |%adverbs);
-                    unless $target eq '' || $!backend.is_textual_stage($target) || %adverbs<output> {
+                    unless $target eq '' || $!backend.is_textual_stage($target) || %adverbs<output> || %adverbs<o> {
                         self.dumper($result, $target, |%adverbs);
                     }
                 }
@@ -334,8 +334,8 @@ class HLL::Compiler does HLL::Backend::Default {
                 elsif %adverbs<combine> { $result := self.evalfiles(@a, |%adverbs) }
                 else { $result := self.evalfiles(@a[0], |@a, |%adverbs) }
 
-                if !nqp::isnull($result) && ($!backend.is_textual_stage($target) || %adverbs<output>) {
-                    my $output := %adverbs<output>;
+                if !nqp::isnull($result) && ($!backend.is_textual_stage($target) || %adverbs<output> || %adverbs<o>) {
+                    my $output := %adverbs<output>//%adverbs<o>;
                     my $fh := ($output eq '' || $output eq '-')
                             ?? stdout()
                             !! open($output, :w);
@@ -443,7 +443,7 @@ class HLL::Compiler does HLL::Backend::Default {
         my $code := join('', @codes);
         my $?FILES := %adverbs<source-name> || join(' ', @files);
         my $r := self.eval($code, |@args, |%adverbs);
-        if $target eq '' || $!backend.is_textual_stage($target) || %adverbs<output> {
+        if $target eq '' || $!backend.is_textual_stage($target) || %adverbs<output> || %adverbs<o> {
             return $r;
         } else {
             return self.dumper($r, $target, |%adverbs);

--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -798,8 +798,8 @@ class HLL::Backend::MoarVM {
 
     method mbc($mast, *%adverbs) {
         my $assmblr := nqp::getcomp('MAST');
-        if %adverbs<target> eq 'mbc' && %adverbs<output> {
-            $assmblr.assemble_to_file($mast, %adverbs<output>);
+        if %adverbs<target> eq 'mbc' && (%adverbs<output> || %adverbs<o>) {
+            $assmblr.assemble_to_file($mast, %adverbs<output> // %adverbs<o>);
             nqp::null()
         }
         else {


### PR DESCRIPTION
It's been documented as existing for a long time, but seems to have
never been implemented.

We could also just remove it as an option, which would mean we'd need to remove it from the Rakudo help text (https://github.com/rakudo/rakudo/blob/master/src/Perl6/Compiler.nqp#L214)