### PR TITLE
Tests for `nqp::coerce_si`

### DIFF
--- a/t/nqp/109-coercions.t
+++ b/t/nqp/109-coercions.t
@@ -1,4 +1,4 @@
-plan(28);
+plan(348);
 
 my sub isnan($n) {
     nqp::isnanorinf($n) && nqp::isne_n($n, nqp::inf()) && nqp::isne_n($n, nqp::neginf());
@@ -65,4 +65,45 @@ is($int32_30, 30, 'num to int32 conversion');
   my int $int32 := 30;
   my str $str := $int32;
   is($str, '30', 'int32 to str conversion');
+}
+
+my @all_ws;
+for "\t", "\n", nqp::chr(11), "\f", "\r", " " -> $ws {
+    nqp::push(@all_ws , $ws);
+    my $ord := nqp::ord($ws);
+    is(nqp::coerce_si($ws), 0, "coerce_si(chr $ord) is 0");
+    my $str := $ws ~ '42';
+    is(nqp::coerce_si($str), 42, "coerce_si treats chr $ord as whitespace");
+    my $str2 := $ws ~ $ws ~ '42';
+    is(nqp::coerce_si($str2), 42, "coerce_si treats 2 chr $ord as whitespace");
+}
+is(nqp::coerce_si(nqp::join("", @all_ws) ~ '54'), 54, "All whitespace is ignored");
+
+for '6', ' 6', '  6', '  6 ', '  6a', ' 6 9' -> $six {
+    is(nqp::coerce_si($six), 6, "coerce_si('$six')");
+}
+
+for '-6', ' -6', '  -6', '  -6 ', '  -6a', ' -6 9' -> $six {
+    is(nqp::coerce_si($six), -6, "coerce_si('$six')");
+}
+
+for '+6', ' +6', '  +6', '  +6 ', '  +6a', ' +6 9' -> $six {
+    is(nqp::coerce_si($six), 6, "coerce_si('$six')");
+}
+
+for '+', '-', '+ 9', '- 9', '++', '+-', '-+', '--', '++9', '+-9', '-+9', '--9' -> $str {
+    for "", " ", "  " -> $spaces {
+        my $input := $spaces ~ $str;
+        is(nqp::coerce_si($input), 0, "coerce_si('$input') is 0");
+    }
+}
+
+my $ord := 0;
+
+while ($ord < 257) {
+    my $chr := nqp::chr($ord);
+    if nqp::islt_s($chr, '0') || nqp::isgt_s($chr, '9') {
+        is(nqp::coerce_si($chr), 0, "coerce_si(chr $ord) is 0");
+    }
+    ++$ord;
 }


### PR DESCRIPTION
`coerce_si` is not sufficiently tested. This draft PR asks what we should test (and hence specify)

Currently with MoarVM master we see this:

```
Iteration past end of grapheme iterator
   at -e:1  (<ephemeral file>:<mainline>)
 from gen/moar/stage2/NQPHLL.nqp:1949  (/home/nick/Perl/nqp/NQPHLL.moarvm:eval)
 from gen/moar/stage2/NQPHLL.nqp:2059  (/home/nick/Perl/nqp/NQPHLL.moarvm:)
 from gen/moar/stage2/NQPHLL.nqp:2114  (/home/nick/Perl/nqp/NQPHLL.moarvm:command_eval)
 from gen/moar/stage2/NQPHLL.nqp:2039  (/home/nick/Perl/nqp/NQPHLL.moarvm:command_line)
 from gen/moar/stage2/NQP.nqp:4111  (nqp.moarvm:MAIN)
 from gen/moar/stage2/NQP.nqp:1  (nqp.moarvm:<mainline>)
 from <unknown>:1  (nqp.moarvm:<main>)
 from <unknown>:1  (nqp.moarvm:<entry>)
```

which is a change in behaviour from all releases. This is caused by MoarVM/moarvm@b80996fff3edbdd06f3d24cd02a022770e338035 (and will soon be fixed)

However, it's unclear **what** the desired behaviour is for corner cases. The tests here all pass once MoarVM is fixed. However, they would fail on released nqp

MoarVM used to use `strtoll`, which returns 0 on parsing failures. However, the call `MVM_string_ascii_encode_any` would throw an exception for any character outside of 0-127, hence the tests here fail like this:

```
ok 205 - coerce_si(chr 127) is 0
Error encoding ASCII string: could not encode codepoint 128
   at /home/nick/test/109-coercions.t:106  (<ephemeral file>:<mainline>)
 from gen/moar/stage2/NQPHLL.nqp:1949  (/home/nick/Perl/nqp/NQPHLL.moarvm:eval)
 from gen/moar/stage2/NQPHLL.nqp:2154  (/home/nick/Perl/nqp/NQPHLL.moarvm:evalfiles)
 from gen/moar/stage2/NQPHLL.nqp:2114  (/home/nick/Perl/nqp/NQPHLL.moarvm:command_eval)
 from gen/moar/stage2/NQPHLL.nqp:2039  (/home/nick/Perl/nqp/NQPHLL.moarvm:command_line)
 from gen/moar/stage2/NQP.nqp:4111  (nqp.moarvm:MAIN)
 from gen/moar/stage2/NQP.nqp:1  (nqp.moarvm:<mainline>)
 from <unknown>:1  (nqp.moarvm:<main>)
 from <unknown>:1  (nqp.moarvm:<entry>)
```

JVM is much stricter, failing at the first new test:

```
ok 28 - int32 to str conversion
java.lang.NumberFormatException: For input string: "    "
  in <mainline> (/home/nick/test/109-coercions.t:109)
  in eval (gen/jvm/stage2/NQPHLL.nqp:1217)
  in evalfiles (gen/jvm/stage2/NQPHLL.nqp:1461)
  in command_eval (gen/jvm/stage2/NQPHLL.nqp:1351)
  in command_line (gen/jvm/stage2/NQPHLL.nqp:1310)
  in MAIN (gen/jvm/stage2/NQP.nqp:4191)
  in <mainline> (gen/jvm/stage2/NQP.nqp:4187)
  in <anon> (gen/jvm/stage2/NQP.nqp)
```

@MasterDuke17 reports that the relevant conversion API we use is very exacting:

> The characters in the string must all be decimal digits except that the first character may be an ASCII minus sign '-' (\u002D') to indicate a negative value or an ASCII plus sign '+' ('\u002B') to indicate a positive value.

Hence **any** spaces are right out:

```
$ ./nqp-j -e 'nqp::say(nqp::coerce_si(" 42"));'
java.lang.NumberFormatException: For input string: " 42"
  in <mainline> (-e:1)
  in eval (gen/jvm/stage2/NQPHLL.nqp:1217)
  in <anon> (gen/jvm/stage2/NQPHLL.nqp:1329)
  in command_eval (gen/jvm/stage2/NQPHLL.nqp:1326)
  in command_line (gen/jvm/stage2/NQPHLL.nqp:1310)
  in MAIN (gen/jvm/stage2/NQP.nqp:4191)
  in <mainline> (gen/jvm/stage2/NQP.nqp:4187)
  in <anon> (gen/jvm/stage2/NQP.nqp)
```


Hence the question is - *what should the spec be?*

I'm happy to recode either MoarVM or the Java code (or both) to be consistent, but I'd like to have a more tightly defined spec of how much slop we're allowed in the number, and for which cases we throw an exception, which cases we return 0, which leading characters we can ignore, and which cases we just ignore "trailing garbage"