### PR TITLE
Fix race when checking for global uniques

### DIFF
--- a/src/QAST/Node.nqp
+++ b/src/QAST/Node.nqp
@@ -111,9 +111,7 @@ class QAST::Node {
     my %uniques;
     method unique($prefix) {
         nqp::lock($uniques_lock);
-        my $id := nqp::existskey(%uniques, $prefix) ??
-            (%uniques{$prefix} := %uniques{$prefix} + 1) !!
-            (%uniques{$prefix} := 1);
+        my $id := ++%uniques{$prefix};
         nqp::unlock($uniques_lock);
         $prefix ~ '_' ~ $id
     }

--- a/src/QAST/Node.nqp
+++ b/src/QAST/Node.nqp
@@ -107,13 +107,14 @@ class QAST::Node {
         %!annotations := nqp::null();
     }
 
-    my %global-uniques;
+    my $uniques_lock := NQPLock.new;
+    my %uniques;
     method unique($prefix) {
-        my %uniques := nqp::clone(%global-uniques);
+        nqp::lock($uniques_lock);
         my $id := nqp::existskey(%uniques, $prefix) ??
             (%uniques{$prefix} := %uniques{$prefix} + 1) !!
             (%uniques{$prefix} := 1);
-        %global-uniques := %uniques;
+        nqp::unlock($uniques_lock);
         $prefix ~ '_' ~ $id
     }
 

--- a/src/QAST/Node.nqp
+++ b/src/QAST/Node.nqp
@@ -107,11 +107,13 @@ class QAST::Node {
         %!annotations := nqp::null();
     }
 
-    my %uniques;
+    my %global-uniques;
     method unique($prefix) {
+        my %uniques := nqp::clone(%global-uniques);
         my $id := nqp::existskey(%uniques, $prefix) ??
             (%uniques{$prefix} := %uniques{$prefix} + 1) !!
             (%uniques{$prefix} := 1);
+        %global-uniques := %uniques;
         $prefix ~ '_' ~ $id
     }
 


### PR DESCRIPTION
As inferred from a stack trace from code that was doing EVAL inside
of a hyper:
````
MoarVM oops: MVM_str_hash_fetch_nocheck called with a stale hashtable pointer
   at gen/moar/stage2/QASTNode.nqp:249  (.../install/share/nqp/lib/QASTNode.moarvm:unique)
 from gen/moar/Optimizer.nqp:780  (.../install/share/perl6/lib/Perl6/Optimizer.moarvm:lexical_vars_to_locals)
 from gen/moar/Optimizer.nqp:2397  (.../install/share/perl6/lib/Perl6/Optimizer.moarvm:visit_block)
 from gen/moar/Optimizer.nqp:2316  (.../install/share/perl6/lib/Perl6/Optimizer.moarvm:optimize)
 from gen/moar/Compiler.nqp:124  (.../install/share/perl6/lib/Perl6/Compiler.moarvm:optimize)
 from gen/moar/stage2/NQPHLL.nqp:2217  (.../install/share/nqp/lib/NQPHLL.moarvm:execute_stage)
````