### PR TITLE
[JVM] Handle unsignedness for CStruct, CPPStruct, CUnion

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CPPStruct.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CPPStruct.java
@@ -181,7 +181,7 @@ public class CPPStruct extends REPR {
         REPR repr = info.type.st.REPR;
         StorageSpec spec = repr.get_storage_spec(tc, info.type.st);
         info.bits = spec.bits;
-        if (spec.inlineable == StorageSpec.INLINED && (spec.boxed_primitive == StorageSpec.BP_INT || spec.boxed_primitive == StorageSpec.BP_UINT)) {
+        if (spec.inlineable == StorageSpec.INLINED && spec.boxed_primitive == StorageSpec.BP_INT) {
             if (spec.bits == 8) {
                 info.argType = ArgType.CHAR;
                 return "B";
@@ -200,6 +200,28 @@ public class CPPStruct extends REPR {
             }
             else {
                 ExceptionHandling.dieInternal(tc, "CPPStruct representation only handles 8, 16, 32 and 64 bit ints");
+                return null;
+            }
+        }
+        else if (spec.inlineable == StorageSpec.INLINED && spec.boxed_primitive == StorageSpec.BP_UINT) {
+            if (spec.bits == 8) {
+                info.argType = ArgType.UCHAR;
+                return "B";
+            }
+            else if (spec.bits == 16) {
+                info.argType = ArgType.USHORT;
+                return "S";
+            }
+            else if (spec.bits == 32) {
+                info.argType = ArgType.UINT;
+                return "I";
+            }
+            else if (spec.bits == 64) {
+                info.argType = ArgType.ULONG;
+                return "J";
+            }
+            else {
+                ExceptionHandling.dieInternal(tc, "CPPStruct representation only handles 8, 16, 32 and 64 bit uints");
                 return null;
             }
         }

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CPPStructInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CPPStructInstance.java
@@ -53,18 +53,22 @@ public class CPPStructInstance extends SixModelObject implements Refreshable {
         Object value;
         switch (info.argType) {
         case CHAR:
+        case UCHAR:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (byte) tc.native_i;
             break;
         case SHORT:
+        case USHORT:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (short) tc.native_i;
             break;
         case INT:
+        case UINT:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (int) tc.native_i;
             break;
         case LONG:
+        case ULONG:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (long) tc.native_i;
             break;
@@ -132,6 +136,35 @@ public class CPPStructInstance extends SixModelObject implements Refreshable {
             tc.native_i = ((Integer) o).intValue();
             break;
         case LONG:
+            tc.native_type = ThreadContext.NATIVE_INT;
+            tc.native_i = ((Long) o).longValue();
+            break;
+        case UCHAR: {
+            tc.native_type = ThreadContext.NATIVE_INT;
+            long val = ((Byte) o).byteValue();
+            if (val < 0)
+                val += 0x100;
+            tc.native_i = val;
+            break;
+        }
+        case USHORT: {
+            tc.native_type = ThreadContext.NATIVE_INT;
+            long val = ((Short) o).shortValue();
+            if (val < 0)
+                val += 0x10000;
+            tc.native_i = val;
+            break;
+        }
+        case UINT: {
+            tc.native_type = ThreadContext.NATIVE_INT;
+            long val = ((Integer) o).intValue();
+            if (val < 0)
+                val += 0x100000000L;
+            tc.native_i = val;
+            break;
+        }
+        case ULONG:
+            /* TODO: handle unsignedness properly. */
             tc.native_type = ThreadContext.NATIVE_INT;
             tc.native_i = ((Long) o).longValue();
             break;

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CStruct.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CStruct.java
@@ -186,7 +186,7 @@ public class CStruct extends REPR {
         REPR repr = info.type.st.REPR;
         StorageSpec spec = repr.get_storage_spec(tc, info.type.st);
         info.bits = spec.bits;
-        if (spec.inlineable == StorageSpec.INLINED && (spec.boxed_primitive == StorageSpec.BP_INT || spec.boxed_primitive == StorageSpec.BP_UINT)) {
+        if (spec.inlineable == StorageSpec.INLINED && spec.boxed_primitive == StorageSpec.BP_INT) {
             if (spec.bits == 8) {
                 info.argType = ArgType.CHAR;
                 return "B";
@@ -205,6 +205,28 @@ public class CStruct extends REPR {
             }
             else {
                 ExceptionHandling.dieInternal(tc, "CStruct representation only handles 8, 16, 32 and 64 bit ints");
+                return null;
+            }
+        }
+        else if (spec.inlineable == StorageSpec.INLINED && spec.boxed_primitive == StorageSpec.BP_UINT) {
+            if (spec.bits == 8) {
+                info.argType = ArgType.UCHAR;
+                return "B";
+            }
+            else if (spec.bits == 16) {
+                info.argType = ArgType.USHORT;
+                return "S";
+            }
+            else if (spec.bits == 32) {
+                info.argType = ArgType.UINT;
+                return "I";
+            }
+            else if (spec.bits == 64) {
+                info.argType = ArgType.ULONG;
+                return "J";
+            }
+            else {
+                ExceptionHandling.dieInternal(tc, "CStruct representation only handles 8, 16, 32 and 64 bit uints");
                 return null;
             }
         }

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CStructInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CStructInstance.java
@@ -54,18 +54,22 @@ public class CStructInstance extends SixModelObject implements Refreshable {
         Object value;
         switch (info.argType) {
         case CHAR:
+        case UCHAR:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (byte) tc.native_i;
             break;
         case SHORT:
+        case USHORT:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (short) tc.native_i;
             break;
         case INT:
+        case UINT:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (int) tc.native_i;
             break;
         case LONG:
+        case ULONG:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (long) tc.native_i;
             break;
@@ -133,6 +137,35 @@ public class CStructInstance extends SixModelObject implements Refreshable {
             tc.native_i = ((Integer) o).intValue();
             break;
         case LONG:
+            tc.native_type = ThreadContext.NATIVE_INT;
+            tc.native_i = ((Long) o).longValue();
+            break;
+        case UCHAR: {
+            tc.native_type = ThreadContext.NATIVE_INT;
+            long val = ((Byte) o).byteValue();
+            if (val < 0)
+                val += 0x100;
+            tc.native_i = val;
+            break;
+        }
+        case USHORT: {
+            tc.native_type = ThreadContext.NATIVE_INT;
+            long val = ((Short) o).shortValue();
+            if (val < 0)
+                val += 0x10000;
+            tc.native_i = val;
+            break;
+        }
+        case UINT: {
+            tc.native_type = ThreadContext.NATIVE_INT;
+            long val = ((Integer) o).intValue();
+            if (val < 0)
+                val += 0x100000000L;
+            tc.native_i = val;
+            break;
+        }
+        case ULONG:
+            /* TODO: handle unsignedness properly. */
             tc.native_type = ThreadContext.NATIVE_INT;
             tc.native_i = ((Long) o).longValue();
             break;

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CUnion.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CUnion.java
@@ -178,7 +178,7 @@ public class CUnion extends REPR {
         REPR repr = info.type.st.REPR;
         StorageSpec spec = repr.get_storage_spec(tc, info.type.st);
         info.bits = spec.bits;
-        if (spec.inlineable == StorageSpec.INLINED && (spec.boxed_primitive == StorageSpec.BP_INT || spec.boxed_primitive == StorageSpec.BP_UINT)) {
+        if (spec.inlineable == StorageSpec.INLINED && spec.boxed_primitive == StorageSpec.BP_INT) {
             if (spec.bits == 8) {
                 info.argType = NativeCall.ArgType.CHAR;
                 return "B";
@@ -197,6 +197,28 @@ public class CUnion extends REPR {
             }
             else {
                 ExceptionHandling.dieInternal(tc, "CUnion representation only handles 8, 16, 32 and 64 bit ints");
+                return null;
+            }
+        }
+        else if (spec.inlineable == StorageSpec.INLINED && spec.boxed_primitive == StorageSpec.BP_UINT) {
+            if (spec.bits == 8) {
+                info.argType = NativeCall.ArgType.UCHAR;
+                return "B";
+            }
+            else if (spec.bits == 16) {
+                info.argType = NativeCall.ArgType.USHORT;
+                return "S";
+            }
+            else if (spec.bits == 32) {
+                info.argType = NativeCall.ArgType.UINT;
+                return "I";
+            }
+            else if (spec.bits == 64) {
+                info.argType = NativeCall.ArgType.ULONG;
+                return "J";
+            }
+            else {
+                ExceptionHandling.dieInternal(tc, "CUnion representation only handles 8, 16, 32 and 64 bit uints");
                 return null;
             }
         }

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CUnionInstance.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/CUnionInstance.java
@@ -53,18 +53,22 @@ public class CUnionInstance extends SixModelObject implements Refreshable {
         Object value;
         switch (info.argType) {
         case CHAR:
+        case UCHAR:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (byte) tc.native_i;
             break;
         case SHORT:
+        case USHORT:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (short) tc.native_i;
             break;
         case INT:
+        case UINT:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (int) tc.native_i;
             break;
         case LONG:
+        case ULONG:
             tc.native_type = ThreadContext.NATIVE_INT;
             value = (long) tc.native_i;
             break;
@@ -132,6 +136,35 @@ public class CUnionInstance extends SixModelObject implements Refreshable {
             tc.native_i = ((Integer) o).intValue();
             break;
         case LONG:
+            tc.native_type = ThreadContext.NATIVE_INT;
+            tc.native_i = ((Long) o).longValue();
+            break;
+        case UCHAR: {
+            tc.native_type = ThreadContext.NATIVE_INT;
+            long val = ((Byte) o).byteValue();
+            if (val < 0)
+                val += 0x100;
+            tc.native_i = val;
+            break;
+        }
+        case USHORT: {
+            tc.native_type = ThreadContext.NATIVE_INT;
+            long val = ((Short) o).shortValue();
+            if (val < 0)
+                val += 0x10000;
+            tc.native_i = val;
+            break;
+        }
+        case UINT: {
+            tc.native_type = ThreadContext.NATIVE_INT;
+            long val = ((Integer) o).intValue();
+            if (val < 0)
+                val += 0x100000000L;
+            tc.native_i = val;
+            break;
+        }
+        case ULONG:
+            /* TODO: handle unsignedness properly. */
             tc.native_type = ThreadContext.NATIVE_INT;
             tc.native_i = ((Long) o).longValue();
             break;


### PR DESCRIPTION
... and CUnion. (At least for uint8, uint16, and uint32).
I mostly copied this from NativeCallOps.java.