### PR TITLE
Remove some not-needed `try`s, or convert to `nqp::can` + the method call

### DIFF
--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -357,7 +357,7 @@ class QRegex::NFA {
         my $subtype := $node.subtype;
 #        note("$indent subrule $from -> $to {$node.name}") if $nfadeb;
         if $node.name eq 'before' && !$node.negate &&
-                nqp::istype((try $node[0][1].ann('orig_qast')), QAST::Regex) {
+                nqp::can($node[0][1], "ann") && nqp::istype($node[0][1].ann('orig_qast'), QAST::Regex) {
             my int $end := self.addstate();
             self.regex_nfa($node[0][1].ann('orig_qast'), $from, $end);
 #            dentout(self.fate($node, $end, $to));

--- a/src/vm/jvm/ModuleLoader.nqp
+++ b/src/vm/jvm/ModuleLoader.nqp
@@ -8,13 +8,11 @@ knowhow ModuleLoader {
         # Put any explicitly specified path on the start of the list.
         my $explicit;
         if !nqp::isnull($explicit_path) {
-            try {
-                my $compiling := %*COMPILING;
-                unless nqp::isnull(%*COMPILING) {
-                    my $options := $compiling<%?OPTIONS>;
-                    unless nqp::isnull($options) {
-                        $explicit := $options{$explicit_path};
-                    }
+            my $compiling := %*COMPILING;
+            unless nqp::isnull($compiling) {
+                my $options := $compiling<%?OPTIONS>;
+                unless nqp::isnull($options) {
+                    $explicit := $options{$explicit_path};
                 }
             }
         }
@@ -61,13 +59,11 @@ knowhow ModuleLoader {
             my $*CTXSAVE := self;
             my $*MAIN_CTX := ModuleLoader;
             my $boot_mode;
-            try {
-                my $compiling := %*COMPILING;
-                unless nqp::isnull(%*COMPILING) {
-                    my $options := $compiling<%?OPTIONS>;
-                    unless nqp::isnull($options) {
-                        $boot_mode := $options<bootstrap>;
-                    }
+            my $compiling := %*COMPILING;
+            unless nqp::isnull($compiling) {
+                my $options := $compiling<%?OPTIONS>;
+                unless nqp::isnull($options) {
+                    $boot_mode := $options<bootstrap>;
                 }
             }
             $boot_mode := !nqp::isnull($boot_mode) && $boot_mode;
@@ -180,13 +176,11 @@ knowhow ModuleLoader {
                 my $*CTXSAVE := self;
                 my $*MAIN_CTX := ModuleLoader;
                 my $boot_mode;
-                try {
-                    my $compiling := %*COMPILING;
-                    unless nqp::isnull(%*COMPILING) {
-                        my $options := $compiling<%?OPTIONS>;
-                        unless nqp::isnull($options) {
-                            $boot_mode := $options<bootstrap>;
-                        }
+                my $compiling := %*COMPILING;
+                unless nqp::isnull($compiling) {
+                    my $options := $compiling<%?OPTIONS>;
+                    unless nqp::isnull($options) {
+                        $boot_mode := $options<bootstrap>;
                     }
                 }
                 $boot_mode := !nqp::isnull($boot_mode) && $boot_mode;

--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -3940,7 +3940,7 @@ class QAST::CompilerJAST {
         unless $*CODEREFS.know_cuid($node.cuid) {
             # Block gets fresh BlockInfo.
             my $*BINDVAL  := 0;
-            my $outer     := try $*BLOCK;
+            my $outer     := $*BLOCK;
             my $block     := BlockInfo.new($node, $outer);
 
             # This array will contain any catch/control exception handlers the
@@ -4358,7 +4358,7 @@ class QAST::CompilerJAST {
 
         # Now go by block type for producing a result; also need to special-case
         # the top-level, where we need no result.
-        if nqp::istype((try $*STACK), StackState) {
+        if nqp::istype($*STACK, StackState) {
             my $blocktype := $node.blocktype;
             if $blocktype eq '' || $blocktype eq 'declaration' || $blocktype eq 'declaration_static' {
                 return self.as_jast(QAST::BVal.new( :value($node) ));
@@ -4482,8 +4482,7 @@ class QAST::CompilerJAST {
     }
 
     multi method as_jast(QAST::Op $node, :$want) {
-        my $hll := '';
-        try $hll := $*HLL;
+        my $hll := $*HLL // '';
         QAST::OperationsJAST.compile_op(self, $hll, $node);
     }
 
@@ -5095,13 +5094,11 @@ class QAST::CompilerJAST {
             $il.append(pop_ins($got));
         }
         elsif $desired == $RT_OBJ {
-            my $hll := '';
-            try $hll := $*HLL;
+            my $hll := $*HLL // '';
             return QAST::OperationsJAST.box(self, $hll, $got);
         }
         elsif $got == $RT_OBJ {
-            my $hll := '';
-            try $hll := $*HLL;
+            my $hll := $*HLL // '';
             return QAST::OperationsJAST.unbox(self, $hll, $desired);
         }
         elsif $desired == $RT_INT {

--- a/src/vm/moar/ModuleLoader.nqp
+++ b/src/vm/moar/ModuleLoader.nqp
@@ -268,8 +268,7 @@ knowhow ModuleLoader {
         my @search_paths;
 
         # Put any explicitly specified path on the start of the list.
-        my $explicit;
-        try { $explicit := nqp::ifnull(nqp::ifnull(%*COMPILING, {})<%?OPTIONS>, {}){$explicit_path}; }
+        my $explicit := nqp::ifnull(nqp::ifnull(%*COMPILING, {})<%?OPTIONS>, {}){$explicit_path};
         if !nqp::isnull($explicit) && nqp::defined($explicit) {
             nqp::push(@search_paths, $explicit);
         }
@@ -305,8 +304,7 @@ knowhow ModuleLoader {
         else {
             my $*CTXSAVE := self;
             my $*MAIN_CTX := ModuleLoader;
-            my $boot_mode;
-            try { $boot_mode := nqp::ifnull(nqp::ifnull(%*COMPILING, {})<%?OPTIONS>, {})<bootstrap>; }
+            my $boot_mode := nqp::ifnull(nqp::ifnull(%*COMPILING, {})<%?OPTIONS>, {})<bootstrap>;
             $boot_mode := !nqp::isnull($boot_mode) && $boot_mode;
             my $preserve_global := nqp::getcurhllsym('GLOBAL');
             nqp::usecompileehllconfig() if $boot_mode;
@@ -407,8 +405,7 @@ knowhow ModuleLoader {
             unless nqp::existskey(%settings_loaded, $path) {
                 my $*CTXSAVE := self;
                 my $*MAIN_CTX := ModuleLoader;
-                my $boot_mode;
-                try { $boot_mode := nqp::ifnull(nqp::ifnull(%*COMPILING, {})<%?OPTIONS>, {})<bootstrap>; }
+                my $boot_mode := nqp::ifnull(nqp::ifnull(%*COMPILING, {})<%?OPTIONS>, {})<bootstrap>;
                 $boot_mode := !nqp::isnull($boot_mode) && $boot_mode;
                 my $preserve_global := nqp::getcurhllsym('GLOBAL');
                 nqp::usecompileehllconfig() if $boot_mode;

--- a/src/vm/moar/QAST/QASTCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTCompilerMAST.nqp
@@ -1018,8 +1018,8 @@ my class MASTCompilerInstance {
                 :compunit($!mast_compunit));
 
             $!mast_compunit.add_frame($frame);
-            try $outer := $*BLOCK;
-            $block     := BlockInfo.new($node, (nqp::defined($outer) ?? $outer !! NQPMu), self);
+            $outer := $*BLOCK;
+            $block := BlockInfo.new($node, (nqp::defined($outer) ?? $outer !! NQPMu), self);
             %*BLOCKS_DONE{$cuid} := [$block, $outer];
 
             # stash the frame by the block's cuid so other references


### PR DESCRIPTION
NQP builds ok and passes `make m-test j-test` and Rakudo builds ok and passes `make m-test m-spectest`.

The one commit I'm not 100% sure about is e1d60fb534b047fdd807fc1601a3090720a2eb72. I've never seen that error happen while taking profiles, so I'm gambling that it's safe to remove the `try`.