### PR TITLE
[JVM] Add missing methods (bind|get)lex_u_si

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
@@ -1108,6 +1108,11 @@ public final class Ops {
             cf = cf.outer;
         return cf.iLex[i];
     }
+    public static long getlex_u_si(CallFrame cf, int i, int si) {
+        while (si-- > 0)
+            cf = cf.outer;
+        return cf.iLex[i];
+    }
     public static double getlex_n_si(CallFrame cf, int i, int si) {
         while (si-- > 0)
             cf = cf.outer;
@@ -1126,6 +1131,12 @@ public final class Ops {
 
     /* Lexical binding in outer scope. */
     public static long bindlex_i_si(long v, CallFrame cf, int i, int si) {
+        while (si-- > 0)
+            cf = cf.outer;
+        cf.iLex[i] = v;
+        return v;
+    }
+    public static long bindlex_u_si(long v, CallFrame cf, int i, int si) {
         while (si-- > 0)
             cf = cf.outer;
         cf.iLex[i] = v;


### PR DESCRIPTION
At least getlex_u_si is called in S09-typed-arrays/native-int.t and
friends after recent uintificatation of native arrays in Rakudo.
The methods behave exactly like the *_i_si versions for now.