### PR TITLE
Speed up "sorted_keys" sub for < 3 elements

### DIFF
--- a/src/core/Hash.nqp
+++ b/src/core/Hash.nqp
@@ -9,57 +9,66 @@ sub hash(*%new) {
 # instead.
 sub sorted_keys($hash) {
     my @keys := nqp::list_s();
-    for $hash {
-        nqp::push_s(@keys, $_.key);
-    }
 
-    sub sift_down(@a, int $start, int $end) {
-        my int $root := $start;
-        my int $child;
-        my int $swap;
+    if nqp::elems($hash) -> int $count {
+        my $iter := nqp::iterator($hash);
+        nqp::while(
+          $iter,
+          nqp::push_s(@keys,nqp::iterkey_s(nqp::shift($iter)))
+        );
 
-        while 2*$root + 1 <= $end {
-            $child := 2*$root + 1;
-            $swap := $root;
-
-            if nqp::atpos_s(@a, $swap) gt nqp::atpos_s(@a, $child) {
-                $swap := $child;
+        if $count == 1 {
+            # all ok already
+        }
+        elsif $count == 2 {
+            # swap if necessary
+            if nqp::atpos_s(@keys, 0) gt nqp::atpos_s(@keys, 1) {
+                nqp::push_s(@keys, nqp::shift_s(@keys));
             }
-            if $child + 1 <= $end && nqp::atpos_s(@a, $swap) ge nqp::atpos_s(@a, $child + 1) {
-                $swap := $child + 1;
+        }
+        else {
+            # need to do actual sorting
+            sub sift_down(@a, int $start, int $end) {
+                my int $root := $start;
+                my int $child;
+                my int $swap;
+
+                while 2*$root + 1 <= $end {
+                    $child := 2*$root + 1;
+                    $swap := $root;
+
+                    if nqp::atpos_s(@a, $swap) gt nqp::atpos_s(@a, $child) {
+                        $swap := $child;
+                    }
+                    if $child + 1 <= $end && nqp::atpos_s(@a, $swap) ge nqp::atpos_s(@a, $child + 1) {
+                        $swap := $child + 1;
+                    }
+                    if $swap == $root {
+                        return;
+                    } else {
+                        my str $tmp := nqp::atpos_s(@a, $root);
+                        nqp::bindpos_s(@a, $root, nqp::atpos_s(@a, $swap));
+                        nqp::bindpos_s(@a, $swap, $tmp);
+                        $root := $swap;
+                    }
+                }
             }
-            if $swap == $root {
-                return;
-            } else {
-                my str $tmp := nqp::atpos_s(@a, $root);
-                nqp::bindpos_s(@a, $root, nqp::atpos_s(@a, $swap));
-                nqp::bindpos_s(@a, $swap, $tmp);
-                $root := $swap;
+
+            my int $start := $count / 2;
+            my int $end := $count - 1;
+            while --$start >= 0 {
+                sift_down(@keys, $start, $end);
+            }
+
+            while $end > 0 {
+                my str $swap := nqp::atpos_s(@keys, $end);
+                nqp::bindpos_s(@keys, $end, nqp::atpos_s(@keys, 0));
+                nqp::bindpos_s(@keys, 0, $swap);
+                $end := $end - 1;
+                sift_down(@keys, 0, $end);
             }
         }
     }
 
-    my int $count := +@keys;
-    if $count < 3 {
-        if $count == 2 && nqp::atpos_s(@keys, 0) gt nqp::atpos_s(@keys, 1) {
-            nqp::push_s(@keys, nqp::shift_s(@keys));
-        }
-        return @keys;
-    }
-    my int $start := $count / 2 - 1;
-    my int $end := $count - 1;
-    while $start >= 0 {
-        sift_down(@keys, $start, $end);
-        $start := $start - 1;
-    }
-
-    while $end > 0 {
-        my str $swap := nqp::atpos_s(@keys, $end);
-        nqp::bindpos_s(@keys, $end, nqp::atpos_s(@keys, 0));
-        nqp::bindpos_s(@keys, 0, $swap);
-        $end := $end - 1;
-        sift_down(@keys, 0, $end);
-    }
-
-    return @keys;
+    @keys
 }

--- a/src/core/Hash.nqp
+++ b/src/core/Hash.nqp
@@ -10,6 +10,7 @@ sub hash(*%new) {
 sub sorted_keys($hash) {
     my @keys := nqp::list_s();
 
+    # not empty
     if nqp::elems($hash) -> int $count {
         my $iter := nqp::iterator($hash);
         nqp::while(
@@ -17,16 +18,8 @@ sub sorted_keys($hash) {
           nqp::push_s(@keys,nqp::iterkey_s(nqp::shift($iter)))
         );
 
-        if $count == 1 {
-            # all ok already
-        }
-        elsif $count == 2 {
-            # swap if necessary
-            if nqp::atpos_s(@keys, 0) gt nqp::atpos_s(@keys, 1) {
-                nqp::push_s(@keys, nqp::shift_s(@keys));
-            }
-        }
-        else {
+        # need to do actual sorting
+        if $count > 2 {
             # need to do actual sorting
             sub sift_down(@a, int $start, int $end) {
                 my int $root := $start;
@@ -67,6 +60,12 @@ sub sorted_keys($hash) {
                 $end := $end - 1;
                 sift_down(@keys, 0, $end);
             }
+        }
+        # swap if necessary
+        else {
+            nqp::push_s(@keys, nqp::shift_s(@keys))
+              if $count == 2
+              && nqp::atpos_s(@keys, 0) gt nqp::atpos_s(@keys, 1);
         }
     }
 

--- a/src/core/Hash.nqp
+++ b/src/core/Hash.nqp
@@ -6,7 +6,7 @@ sub hash(*%new) {
 # so a bubble sort would be fine. However, the
 # number can get much larger (e.g., when profiling
 # a build of the Rakudo settings), so use a heapsort
-# instead.
+# instead.  Note that this sorts in **reverse** order.
 sub sorted_keys($hash) {
     my @keys := nqp::list_s();
     my $iter := nqp::iterator($hash);
@@ -47,7 +47,6 @@ sub sorted_keys($hash) {
         my int $end := $count - 1;
         while --$start >= 0 {
             sift_down(@keys, $start, $end);
-            $start := $start - 1;
         }
 
         while $end > 0 {
@@ -58,7 +57,7 @@ sub sorted_keys($hash) {
             sift_down(@keys, 0, $end);
         }
     }
-    elsif $count == 2 && nqp::atpos_s(@keys, 0) gt nqp::atpos_s(@keys, 1) {
+    elsif $count == 2 && nqp::atpos_s(@keys, 0) lt nqp::atpos_s(@keys, 1) {
         nqp::push_s(@keys, nqp::shift_s(@keys));
     }
 

--- a/src/core/Hash.nqp
+++ b/src/core/Hash.nqp
@@ -9,64 +9,57 @@ sub hash(*%new) {
 # instead.
 sub sorted_keys($hash) {
     my @keys := nqp::list_s();
+    my $iter := nqp::iterator($hash);
+    nqp::while(
+      $iter,
+      nqp::push_s(@keys,nqp::iterkey_s(nqp::shift($iter)))
+    );
 
-    # not empty
-    if nqp::elems($hash) -> int $count {
-        my $iter := nqp::iterator($hash);
-        nqp::while(
-          $iter,
-          nqp::push_s(@keys,nqp::iterkey_s(nqp::shift($iter)))
-        );
+    sub sift_down(@a, int $start, int $end) {
+        my int $root := $start;
+        my int $child;
+        my int $swap;
 
-        # need to do actual sorting
-        if $count > 2 {
-            # need to do actual sorting
-            sub sift_down(@a, int $start, int $end) {
-                my int $root := $start;
-                my int $child;
-                my int $swap;
+        while 2*$root + 1 <= $end {
+            $child := 2*$root + 1;
+            $swap := $root;
 
-                while 2*$root + 1 <= $end {
-                    $child := 2*$root + 1;
-                    $swap := $root;
-
-                    if nqp::atpos_s(@a, $swap) gt nqp::atpos_s(@a, $child) {
-                        $swap := $child;
-                    }
-                    if $child + 1 <= $end && nqp::atpos_s(@a, $swap) ge nqp::atpos_s(@a, $child + 1) {
-                        $swap := $child + 1;
-                    }
-                    if $swap == $root {
-                        return;
-                    } else {
-                        my str $tmp := nqp::atpos_s(@a, $root);
-                        nqp::bindpos_s(@a, $root, nqp::atpos_s(@a, $swap));
-                        nqp::bindpos_s(@a, $swap, $tmp);
-                        $root := $swap;
-                    }
-                }
+            if nqp::atpos_s(@a, $swap) gt nqp::atpos_s(@a, $child) {
+                $swap := $child;
             }
-
-            my int $start := $count / 2;
-            my int $end := $count - 1;
-            while --$start >= 0 {
-                sift_down(@keys, $start, $end);
+            if $child + 1 <= $end && nqp::atpos_s(@a, $swap) ge nqp::atpos_s(@a, $child + 1) {
+                $swap := $child + 1;
             }
-
-            while $end > 0 {
-                my str $swap := nqp::atpos_s(@keys, $end);
-                nqp::bindpos_s(@keys, $end, nqp::atpos_s(@keys, 0));
-                nqp::bindpos_s(@keys, 0, $swap);
-                $end := $end - 1;
-                sift_down(@keys, 0, $end);
+            if $swap == $root {
+                return;
+            } else {
+                my str $tmp := nqp::atpos_s(@a, $root);
+                nqp::bindpos_s(@a, $root, nqp::atpos_s(@a, $swap));
+                nqp::bindpos_s(@a, $swap, $tmp);
+                $root := $swap;
             }
         }
-        # swap if necessary
-        else {
-            nqp::push_s(@keys, nqp::shift_s(@keys))
-              if $count == 2
-              && nqp::atpos_s(@keys, 0) gt nqp::atpos_s(@keys, 1);
+    }
+
+    my int $count := +@keys;
+    if $count > 2 {
+        my int $start := $count / 2;
+        my int $end := $count - 1;
+        while --$start >= 0 {
+            sift_down(@keys, $start, $end);
+            $start := $start - 1;
         }
+
+        while $end > 0 {
+            my str $swap := nqp::atpos_s(@keys, $end);
+            nqp::bindpos_s(@keys, $end, nqp::atpos_s(@keys, 0));
+            nqp::bindpos_s(@keys, 0, $swap);
+            $end := $end - 1;
+            sift_down(@keys, 0, $end);
+        }
+    }
+    elsif $count == 2 && nqp::atpos_s(@keys, 0) gt nqp::atpos_s(@keys, 1) {
+        nqp::push_s(@keys, nqp::shift_s(@keys));
     }
 
     @keys

--- a/t/nqp/018-associative.t
+++ b/t/nqp/018-associative.t
@@ -1,6 +1,6 @@
 # check hash access methods
 
-plan(19);
+plan(23);
 
 my %h;
 
@@ -48,3 +48,22 @@ sub as_return_value() {
 }
 
 ok(nqp::eqaddr(as_return_value(), NQPMu), 'getting a NQPMu for a missing hash member when used a s return value');
+
+my @keys := <a b c d e f g h i j>;
+my @values := 1,2,3,4,5,6,7,8,9,10;
+
+my %sh;
+for @values {
+    %sh{@keys[$_-1]} := $_;
+}
+
+is(nqp::join("",sorted_keys(%sh)), nqp::flip(nqp::join("",@keys)), 'did we get sorted keys');
+
+my %eh;
+is(nqp::join("",sorted_keys(%eh)), "", 'did we get no keys');
+
+%eh<a> := 1;
+is(nqp::join("",sorted_keys(%eh)), "a", 'did we get one key');
+
+%eh<b> := 1;
+is(nqp::join("",sorted_keys(%eh)), "ba", 'did we get two keys');


### PR DESCRIPTION
- check number of elements in hash before doing anything
- if zero, don't do anything
- if more than zero, fetch the *keys* instead of pairs
- if 1 element, we're done
- if 2 elements, swap if necessary
- if more, only *then* do the actual sort
- use decrement in condition, account for that in initialization

Should be faster because of the key fetching algorithm, and
because it doesn't fetch the keys if none are there to fetch.