### PR TITLE
Make some enhancements to atomic integers

### DIFF
--- a/src/core/Counter.nqp
+++ b/src/core/Counter.nqp
@@ -1,0 +1,87 @@
+# This adds bounds to a native atomic uint, giving a few means of handling when
+# those are reached via succ/pred operations:
+#
+# - drop_pred and drop_succ perform said operation only if valid
+# - want_pred and want_succ wait for said operation to become valid
+# - need_pred and need_succ permit underflows and overflows respectively
+#
+# This roughly translates to a semaphore's tryacquire/acquire/release
+# operations, which it was originally designed to replicate, to which it
+# performs comparably. We get more flavours of bounds handling and
+# serializability if we ditch that structure, however.
+class Counter {
+    my uint $UINT_MAX := nqp::bitneg_i(0);
+
+    has int $!counter;
+    has int $!blocker;
+
+    method new($counter) {
+        my $self := nqp::create(self);
+        nqp::bindattr_i($self, $?CLASS, '$!counter', $counter);
+        nqp::bindattr_i($self, $?CLASS, '$!blocker', $counter == 0);
+        $self
+    }
+
+    # Gives the predecessor unless we're at the lower bound.
+    method drop_pred() {
+        my $counter := nqp::getattrref_i(self, $?CLASS, '$!counter');
+        if nqp::atomicload_i($counter) -> uint $pred {
+            nqp::barrierfull();
+            nqp::atomicstore_i($counter, ($pred := $pred - 1));
+            nqp::atomicstore_i(nqp::getattrref_i(self, $?CLASS, '$!blocker'), 0) if $pred;
+            $pred
+        }
+        else {
+            0
+        }
+    }
+
+    # Gives the predecessor, waiting for one to become valid if need be.
+    method want_pred() {
+        my $blocker := nqp::getattrref_i(self, $?CLASS, '$!blocker');
+        nqp::threadyield()
+            while nqp::cas_i($blocker, 0, 1);
+        nqp::atomicstore_i($blocker, 0)
+            if my uint $pred := nqp::sub_i(nqp::getattrref_i(self, $?CLASS, '$!counter'), 1);
+        $pred
+    }
+
+    # Gives the predecessor immediately, ignoring underflows.
+    method need_pred() {
+        nqp::atomicstore_i(nqp::getattrref_i(self, $?CLASS, '$!blocker'), 1)
+            if my uint $pred := nqp::sub_i(nqp::getattrref_i(self, $?CLASS, '$!counter'), 1);
+        $pred
+    }
+
+    # Gives the successor unless we're at the upper bound.
+    method drop_succ() {
+        my $counter := nqp::getattrref_i(self, $?CLASS, '$!counter');
+        if (my uint $succ := nqp::atomicload_i($counter)) < $UINT_MAX {
+            nqp::barrierfull();
+            nqp::atomicstore_i($counter, ($succ := $succ + 1));
+            nqp::atomicstore_i(nqp::getattrref_i(self, $?CLASS, '$!blocker'), 0);
+            $succ
+        }
+        else {
+            $UINT_MAX
+        }
+    }
+
+    # Gives the successor, waiting for one to become valid if need be.
+    method want_succ() {
+        my $counter := nqp::getattrref_i(self, $?CLASS, '$!counter');
+        nqp::threadyield()
+            while (my uint $succ := nqp::atomicload_i($counter)) == $UINT_MAX;
+        nqp::barrierfull();
+        nqp::atomicstore_i($counter, ($succ := $succ + 1));
+        nqp::atomicstore_i(nqp::getattrref_i(self, $?CLASS, '$!blocker'), 0);
+        $succ
+    }
+
+    # Gives the predecessor immediately, ignoring overflows.
+    method need_succ() {
+        my uint $succ := nqp::add_i(nqp::getattrref_i(self, $?CLASS, '$!counter'), 1);
+        nqp::atomicstore_i(nqp::getattrref_i(self, $?CLASS, '$!blocker'), $succ == 0);
+        $succ
+    }
+}

--- a/src/core/NQPMu.nqp
+++ b/src/core/NQPMu.nqp
@@ -136,6 +136,28 @@ nqp::sethllconfig('nqp', nqp::hash(
     'istype_dispatcher', 'nqp-istype',
     'isinvokable_dispatcher', 'nqp-isinvokable',
 #?endif
+    'int_lex_ref', IntLexRef,
+    'uint_lex_ref', UIntLexRef,
+    'num_lex_ref', NumLexRef,
+    'str_lex_ref', StrLexRef,
+    'int_attr_ref', IntAttrRef,
+    'uint_attr_ref', UIntAttrRef,
+    'num_attr_ref', NumAttrRef,
+    'str_attr_ref', StrAttrRef,
+    'int_pos_ref', IntPosRef,
+    'uint_pos_ref', UIntPosRef,
+    'num_pos_ref', NumPosRef,
+    'str_pos_ref', StrPosRef,
+    'int_multidim_ref', IntMultidimRef,
+    'uint_multidim_ref', UIntMultidimRef,
+    'num_multidim_ref', NumMultidimRef,
+    'str_multidim_ref', StrMultidimRef,
+#?if js
+    'int64_lex_ref', Int64LexRef,
+    'int64_attr_ref', Int64AttrRef,
+    'int64_pos_ref', Int64PosRef,
+    'int64_multidim_ref', Int64MultidimRef,
+#?endif
 ));
 
 #?if moar

--- a/src/core/NativeTypes.nqp
+++ b/src/core/NativeTypes.nqp
@@ -45,3 +45,84 @@ my native num64 is repr('P6num') is nativesize(64) { }
 my native num32 is repr('P6num') is nativesize(32) { }
 
 my native str is repr('P6str') { }
+
+my stub IntLexRef metaclass NQPNativeRefHOW { ... };
+my stub UIntLexRef metaclass NQPNativeRefHOW { ... };
+my stub NumLexRef metaclass NQPNativeRefHOW { ... };
+my stub StrLexRef metaclass NQPNativeRefHOW { ... };
+my stub IntAttrRef metaclass NQPNativeRefHOW { ... };
+my stub UIntAttrRef metaclass NQPNativeRefHOW { ... };
+my stub NumAttrRef metaclass NQPNativeRefHOW { ... };
+my stub StrAttrRef metaclass NQPNativeRefHOW { ... };
+my stub IntPosRef metaclass NQPNativeRefHOW { ... };
+my stub UIntPosRef metaclass NQPNativeRefHOW { ... };
+my stub NumPosRef metaclass NQPNativeRefHOW { ... };
+my stub StrPosRef metaclass NQPNativeRefHOW { ... };
+my stub IntMultidimRef metaclass NQPNativeRefHOW { ... };
+my stub UIntMultidimRef metaclass NQPNativeRefHOW { ... };
+my stub NumMultidimRef metaclass NQPNativeRefHOW { ... };
+my stub StrMultidimRef metaclass NQPNativeRefHOW { ... };
+
+#?if js
+my stub Int64LexRef metaclass NQPNativeRefHOW { ... };
+my stub Int64AttrRef metaclass NQPNativeRefHOW { ... };
+my stub Int64PosRef metaclass NQPNativeRefHOW { ... };
+my stub Int64MultidimRef metaclass NQPNativeRefHOW { ... };
+#?endif
+
+# Set up various native reference types.
+sub setup_native_ref_type($type, $primitive, $ref_kind) {
+    $type.HOW.set_native_type($type, $primitive);
+    $type.HOW.set_ref_kind($type, $ref_kind);
+    $type.HOW.compose_repr($type);
+    nqp::setcontspec($type, 'native_ref', nqp::null());
+}
+
+nqp::scwbenable();
+setup_native_ref_type(IntLexRef, int, 'lexical');
+setup_native_ref_type(UIntLexRef, uint, 'lexical');
+setup_native_ref_type(NumLexRef, num, 'lexical');
+setup_native_ref_type(StrLexRef, str, 'lexical');
+setup_native_ref_type(IntAttrRef, int, 'attribute');
+setup_native_ref_type(UIntAttrRef, uint, 'attribute');
+setup_native_ref_type(NumAttrRef, num, 'attribute');
+setup_native_ref_type(StrAttrRef, str, 'attribute');
+setup_native_ref_type(IntPosRef, int, 'positional');
+setup_native_ref_type(UIntPosRef, uint, 'positional');
+setup_native_ref_type(NumPosRef, num, 'positional');
+setup_native_ref_type(StrPosRef, str, 'positional');
+setup_native_ref_type(IntMultidimRef, int, 'multidim');
+setup_native_ref_type(UIntMultidimRef, uint, 'multidim');
+setup_native_ref_type(NumMultidimRef, num, 'multidim');
+setup_native_ref_type(StrMultidimRef, str, 'multidim');
+#?if js
+setup_native_ref_type(Int64LexRef, int64, 'lexical');
+setup_native_ref_type(Int64AttrRef, int64, 'attribute');
+setup_native_ref_type(Int64PosRef, int64, 'positional');
+setup_native_ref_type(Int64MultidimRef, int64, 'multidim');
+#?endif
+
+IntLexRef.HOW.compose(IntLexRef);
+UIntLexRef.HOW.compose(UIntLexRef);
+NumLexRef.HOW.compose(NumLexRef);
+StrLexRef.HOW.compose(StrLexRef);
+IntAttrRef.HOW.compose(IntAttrRef);
+UIntAttrRef.HOW.compose(UIntAttrRef);
+NumAttrRef.HOW.compose(NumAttrRef);
+StrAttrRef.HOW.compose(StrAttrRef);
+IntPosRef.HOW.compose(IntPosRef);
+UIntPosRef.HOW.compose(UIntPosRef);
+NumPosRef.HOW.compose(NumPosRef);
+StrPosRef.HOW.compose(StrPosRef);
+IntMultidimRef.HOW.compose(IntMultidimRef);
+UIntMultidimRef.HOW.compose(UIntMultidimRef);
+NumMultidimRef.HOW.compose(NumMultidimRef);
+StrMultidimRef.HOW.compose(StrMultidimRef);
+
+#?if js
+Int64LexRef.HOW.compose(Int64LexRef);
+Int64AttrRef.HOW.compose(Int64AttrRef);
+Int64PosRef.HOW.compose(Int64PosRef);
+Int64MultidimRef.HOW.compose(Int64MultidimRef);
+#?endif
+nqp::scwbdisable();

--- a/src/how/NQPNativeRefHOW.nqp
+++ b/src/how/NQPNativeRefHOW.nqp
@@ -1,0 +1,72 @@
+knowhow NQPNativeRefHOW {
+    has $!name;
+    has $!type;
+    has $!refkind;
+    has $!composed;
+    has $!repr_composed;
+
+    my $archetypes := Archetypes.new(:nominal);
+    method archetypes() {
+        $archetypes
+    }
+
+    method new(:$name) {
+        my $self := nqp::create(self);
+        nqp::bindattr($self, $?CLASS, '$!name', $name);
+        $self
+    }
+
+    method new_type(:$name) {
+        my $how := self.new();
+        my $obj := nqp::newtype($how, 'NativeRef');
+        nqp::settypehll($obj, 'nqp');
+        nqp::setdebugtypename($obj, $name)
+    }
+
+    method set_native_type($obj, $type) {
+        $!type := $type
+    }
+
+    method native_type($obj) {
+        $!type
+    }
+
+    method set_ref_kind($obj, $refkind) {
+        $!refkind := $refkind
+    }
+
+    method ref_kind($obj) {
+        $!refkind
+    }
+
+    method compose($obj, *%named) {
+        $obj := nqp::decont($obj);
+        self.compose_repr($obj);
+        self.publish_type_cache($obj);
+        $!composed := 1;
+        $obj
+    }
+
+    method is_composed($obj) {
+        $!composed
+    }
+
+    method compose_repr($obj) {
+        unless $!repr_composed {
+            my $info := nqp::hash();
+            $info<nativeref> := nqp::hash();
+            $info<nativeref><type> := nqp::decont($!type);
+            $info<nativeref><refkind> := $!refkind // 'unknown';
+            nqp::composetype(nqp::decont($obj), $info);
+            $!repr_composed := 1;
+        }
+    }
+
+    method repr_composed($obj) {
+        $!repr_composed
+    }
+
+    method publish_type_cache($obj) {
+        nqp::settypecache($obj, nqp::list($obj, $!type))
+    }
+}

--- a/src/vm/moar/NQP/Ops.nqp
+++ b/src/vm/moar/NQP/Ops.nqp
@@ -4,6 +4,7 @@ my int $MVM_reg_int64           := 4;
 my int $MVM_reg_num64           := 6;
 my int $MVM_reg_str             := 7;
 my int $MVM_reg_obj             := 8;
+my int $MVM_reg_uint64          := 20;
 
 $ops.add_hll_op('nqp', 'preinc', -> $qastcomp, $op {
     my $var := $op[0];
@@ -113,6 +114,13 @@ $ops.add_hll_op('nqp', 'falsey', -> $qastcomp, $op {
     if $val.result_kind == $MVM_reg_int64 {
         my $not_reg := $regalloc.fresh_register($MVM_reg_int64);
         MAST::Op.new(:frame($qastcomp.mast_frame),:op<not_i>, $not_reg, $val.result_reg);
+        MAST::InstructionList.new($not_reg, $val.result_kind)
+    }
+    elsif $val.result_kind == $MVM_reg_uint64 {
+        my $tmp_reg := $regalloc.fresh_register($MVM_reg_uint64);
+        my $not_reg := $regalloc.fresh_register($MVM_reg_int64);
+        MAST::Op.new(:frame($qastcomp.mast_frame),:op<coerce_ui>, $not_reg, $val.result_reg);
+        MAST::Op.new(:frame($qastcomp.mast_frame),:op<not_i>, $not_reg, $not_reg);
         MAST::InstructionList.new($not_reg, $MVM_reg_int64)
     }
     elsif $val.result_kind == $MVM_reg_int32 {

--- a/tools/templates/Makefile-common.in
+++ b/tools/templates/Makefile-common.in
@@ -22,6 +22,7 @@ CORE_SETTING_SOURCES = \
   @nfp(src/core/Regex.nqp)@ \
   @nfp(src/core/Hash.nqp)@ \
   @nfp(src/core/NQPLock.nqp)@ \
+  @nfp(src/core/Counter.nqp)@ \
   @nfp(src/core/testing.nqp)@ \
   @nfp(src/core/YOUAREHERE.nqp)@ \
 

--- a/tools/templates/Makefile-common.in
+++ b/tools/templates/Makefile-common.in
@@ -97,6 +97,7 @@ NQP_MO_SOURCES = \
   @nfp(src/how/NQPParametricRoleHOW.nqp)@ \
   @nfp(src/how/NQPClassHOW.nqp)@ \
   @nfp(src/how/NQPNativeHOW.nqp)@ \
+  @nfp(src/how/NQPNativeRefHOW.nqp)@ \
   @nfp(src/how/NQPAttribute.nqp)@ \
   @nfp(src/how/NQPModuleHOW.nqp)@ \
   @nfp(src/how/EXPORTHOW.nqp)@ \


### PR DESCRIPTION
- Give nqp native refs to allow for usage of atomic ops in nqp.
- Introduce a semaphore-like `Counter` that performs comparably.
- I'm getting tired of writing every atomic op twice in Rakudo. Maybe it's time to give the JVM and JS backend atomicops?
- Let Rakudo building at all be the test of native refs, since they will be required at that point in time soon enough.
- `Counter` needs sanity tests in its own right. Swapping out `Semaphore` and its `acquire/release` for a `Counter` and its `want_pred`/`drop_succ` passes OK.
- Takes the place of https://github.com/Raku/nqp/pull/774.