### PR TITLE
[JVM] Implement the objprimunsigned and objprimbits ops

### DIFF
--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2757,6 +2757,7 @@ QAST::OperationsJAST.add_core_op('settypefinalize', -> $qastcomp, $op {
 });
 QAST::OperationsJAST.map_classlib_core_op('objprimspec', $TYPE_OPS, 'objprimspec', [$RT_OBJ], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('objprimunsigned', $TYPE_OPS, 'objprimunsigned', [$RT_OBJ], $RT_INT, :tc);
+QAST::OperationsJAST.map_classlib_core_op('objprimbits', $TYPE_OPS, 'objprimbits', [$RT_OBJ], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('isinvokable', $TYPE_OPS, 'isinvokable', [$RT_OBJ], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('setinvokespec', $TYPE_OPS, 'setinvokespec', [$RT_OBJ, $RT_OBJ, $RT_STR, $RT_OBJ], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('setparameterizer', $TYPE_OPS, 'setparameterizer', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);

--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -2756,6 +2756,7 @@ QAST::OperationsJAST.add_core_op('settypefinalize', -> $qastcomp, $op {
     $qastcomp.as_jast($op[0])
 });
 QAST::OperationsJAST.map_classlib_core_op('objprimspec', $TYPE_OPS, 'objprimspec', [$RT_OBJ], $RT_INT, :tc);
+QAST::OperationsJAST.map_classlib_core_op('objprimunsigned', $TYPE_OPS, 'objprimunsigned', [$RT_OBJ], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('isinvokable', $TYPE_OPS, 'isinvokable', [$RT_OBJ], $RT_INT, :tc);
 QAST::OperationsJAST.map_classlib_core_op('setinvokespec', $TYPE_OPS, 'setinvokespec', [$RT_OBJ, $RT_OBJ, $RT_STR, $RT_OBJ], $RT_OBJ, :tc);
 QAST::OperationsJAST.map_classlib_core_op('setparameterizer', $TYPE_OPS, 'setparameterizer', [$RT_OBJ, $RT_OBJ], $RT_OBJ, :tc);

--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
@@ -2624,6 +2624,9 @@ public final class Ops {
     public static long objprimspec(SixModelObject obj, ThreadContext tc) {
         return isnull(obj) == 1 ? 0 : obj.st.REPR.get_storage_spec(tc, obj.st).boxed_primitive;
     }
+    public static long objprimunsigned(SixModelObject obj, ThreadContext tc) {
+        return isnull(obj) == 1 ? 0 : obj.st.REPR.get_storage_spec(tc, obj.st).is_unsigned;
+    }
     public static SixModelObject setinvokespec(SixModelObject obj, SixModelObject ch,
             String name, SixModelObject invocationHandler, ThreadContext tc) {
         InvocationSpec is = new InvocationSpec();

--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/Ops.java
@@ -2627,6 +2627,9 @@ public final class Ops {
     public static long objprimunsigned(SixModelObject obj, ThreadContext tc) {
         return isnull(obj) == 1 ? 0 : obj.st.REPR.get_storage_spec(tc, obj.st).is_unsigned;
     }
+    public static long objprimbits(SixModelObject obj, ThreadContext tc) {
+        return isnull(obj) == 1 ? 0 : obj.st.REPR.get_storage_spec(tc, obj.st).bits;
+    }
     public static SixModelObject setinvokespec(SixModelObject obj, SixModelObject ch,
             String name, SixModelObject invocationHandler, ThreadContext tc) {
         InvocationSpec is = new InvocationSpec();

--- a/t/nqp/093-oo-ops.t
+++ b/t/nqp/093-oo-ops.t
@@ -1,4 +1,4 @@
-plan(23);
+plan(29);
 class Foo {
     method foo() {
         'bar';
@@ -47,6 +47,14 @@ ok(nqp::objprimspec(num) == 2, 'nqp::objprimspec on num');
 ok(nqp::objprimspec(Foo) == 0, 'nqp::objprimspec on Foo');
 ok(nqp::objprimspec(nqp::null()) == 0, 'nqp::objprimspec on a null');
 
+ok(nqp::objprimunsigned(uint) == 1, 'uint is unsigned');
+ok(nqp::objprimunsigned(int) == 0, 'int is not unsigned');
+ok(nqp::objprimunsigned(num) == 0, 'num is not unsigned');
+ok(nqp::objprimunsigned(str) == 0, 'str is not unsigned');
+ok(nqp::objprimunsigned(nqp::null()) == 0, 'null is not unsigned');
+
+ok(nqp::objprimbits(uint64) == 64, 'sized integers are sizable');
+
 class Base {
 }
 
@@ -71,6 +79,5 @@ class Class1 {
 }
 
 dies-ok({nqp::rebless(Base.new, IntReprClass)}, 'reblessing to an incompatible type is not allowed');
-
 
 dies-ok({nqp::rebless(Extended.new, Base)}, 'can\'t rebless to an incompatible type');


### PR DESCRIPTION
These ops exist alongside `nqp::objprimspec` as storage spec-related ops on MoarVM and the JS backend (going off `git grep` at least). `nqp::objprimunsigned` would be nice to have portably for `Array::Shaped.STORE` in https://github.com/rakudo/rakudo/pull/5062, while `nqp::objprimbits` is just added for consistency's sake. Passes `make test` and a Rakudo build, but requires https://github.com/MoarVM/MoarVM/pull/1724 in order to do so.