### PR TITLE
Add support for RakuAST::Origin::Match

### DIFF
--- a/src/vm/jvm/QAST/Compiler.nqp
+++ b/src/vm/jvm/QAST/Compiler.nqp
@@ -4457,7 +4457,13 @@ class QAST::CompilerJAST {
         for @stmts {
             if $_.node && nqp::can($_.node,'orig') {
                 my $node := $_.node;
-                my $line := HLL::Compiler.lineof($node.orig(), $node.from(), :cache(1), :directives(0));
+                my $line;
+                if nqp::can($node, 'orig-line') {
+                    $line := $node.orig-line();
+                }
+                else {
+                    $line := HLL::Compiler.lineof($node.orig(), $node.from(), :cache(1), :directuves(0));
+                }
                 $il.append(JAST::Annotation.new( :line($line) ));
             }
 

--- a/src/vm/moar/QAST/QASTCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTCompilerMAST.nqp
@@ -1469,9 +1469,17 @@ my class MASTCompilerInstance {
     method compile_annotation($qast) {
         my $node := $qast.node;
         if nqp::isconcrete($node) && nqp::can($node,'orig') {
-            my @line_file := HLL::Compiler.linefileof($node.orig(), $node.from(), :cache(1), :directives(1));
-            my $line := @line_file[0];
-            my $file := @line_file[1] || $!file;
+            my $line;
+            my $file;
+            if nqp::can($node, 'file') && nqp::can($node, 'line') {
+                $line := $node.line();
+                $file := $node.file();
+            }
+            else {
+                my @line_file := HLL::Compiler.linefileof($node.orig(), $node.from(), :cache(1), :directives(1));
+                $line := @line_file[0];
+                $file := @line_file[1] || $!file;
+            }
             MAST::Annotated.new(:$file, :$line);
         }
     }


### PR DESCRIPTION
Actually, any object in `QAST::Node.node` with methods `file`, `line`, and `orig-line` are supported.

In support of rakudo/rakudo#5117.