### PR TITLE
Don't error without git but all needed files are present

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -12,16 +12,19 @@ use File::Path;
 use FindBin;
 
 BEGIN {
-    # Download / Update submodules
-    my $set_config = !qx{git config nqp.initialized};
-    if ( !-e '3rdparty/nqp-configure/LICENSE' ) {
-        my $code = system($^X, 'tools/build/update-submodules.pl', Cwd::cwd(), @ARGV);
-        exit 1 if $code >> 8 != 0;
-        $set_config = 1;
-    }
-    if ($set_config) {
-        system("git config submodule.recurse true");
-        system("git config nqp.initialized 1");
+    # The .git folder is typically missing in release archives.
+    if (-e '.git') {
+        # Download / Update submodules
+        my $set_config = !qx{git config nqp.initialized};
+        if ( !-e '3rdparty/nqp-configure/LICENSE' ) {
+            my $code = system($^X, 'tools/build/update-submodules.pl', Cwd::cwd(), @ARGV);
+            exit 1 if $code >> 8 != 0;
+            $set_config = 1;
+        }
+        if ($set_config) {
+            system("git config submodule.recurse true");
+            system("git config nqp.initialized 1");
+        }
     }
 }
 


### PR DESCRIPTION
If Git is not installed and / or the `.git` folder is not present (typically a release src archive), `Configure.pl` prints error messages about failing to execute `git`. The build continues and succeeds though if all three projects (MoarVM, NQP, Rakudo) are present. This change checks for the presence of the `.git` folder (not present = release archive) and skips the (unnecessary) submodule update in that case.