### PR TITLE
Provide current compiler via $*HLL-COMPILER

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -478,6 +478,7 @@ class HLL::Compiler does HLL::Backend::Default {
         my %*COMPILING := nqp::clone(nqp::ifnull(nqp::getlexdyn('%*COMPILING'), nqp::hash()));
         %*COMPILING<%?OPTIONS> := %adverbs;
         my $*LINEPOSCACHE := $lineposcache;
+        my $*HLL-COMPILER := self;
 
         my $target := nqp::lc(%adverbs<target>);
         my $result := $source;


### PR DESCRIPTION
Beneficial for concurrent compilations.

The symbol is only available at compilation stage.