### PR TITLE
Warn about missing perl5 libs in Configure instead of just crashing

### DIFF
--- a/Configure.pl
+++ b/Configure.pl
@@ -9,7 +9,48 @@ use Getopt::Long;
 use Cwd;
 use File::Spec;
 use File::Path;
-use FindBin;
+
+# These modules can be missing in some cut-down installations of perl5, for
+# example the default system installation of perl5 on Fedora.
+#
+# This check code doesn't go into 3rdparty/nqp-configure because we use
+# FindBin to find and load it.
+BEGIN {
+    my %missing_libs;
+    eval { require FindBin };
+    $missing_libs{"FindBin"} = $@ unless $@ eq '';
+    eval { require IPC::Cmd };
+    $missing_libs{"IPC::Cmd"} = $@ unless $@ eq '';
+    eval { require ExtUtils::Command };
+    $missing_libs{"ExtUtils::Command"} = $@ unless $@ eq '';
+
+    if (keys %missing_libs) {
+        say "==== !!!! ====";
+        say "  Some essential perl5 modules are missing!";
+        say "";
+
+        print "$missing_libs{$_}\n" for (keys %missing_libs);
+        sub display_missing_lib {
+            my $libname = shift;
+            if (exists $missing_libs{$libname}) {
+                say "  - $libname (missing!)";
+            }
+            else {
+                say "  - $libname (found)";
+            }
+        }
+        say "";
+        say "This usually means you are using a cut-down installation of perl5";
+        say "which is what some linux distributions include by default.";
+        say "In order to successfully configure, compile and install nqp and";
+        say "rakudo, you will need at least these perl modules:";
+        say "";
+        display_missing_lib("FindBin");
+        display_missing_lib("IPC::Cmd");
+        display_missing_lib("ExtUtils::Command");
+        exit 1;
+    }
+}
 
 BEGIN {
     # The .git folder is typically missing in release archives.


### PR DESCRIPTION
On a system where some of the standard library is chopped off into modules, Configure --help would crash with the not-too-scrutible error message that perl5 gives when a module isn't installed, so i'm thinking a friendly message would be nice