### PR TITLE
Remove unused apply_transcoding compiler function

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -543,9 +543,6 @@ class HLL::Compiler does HLL::Backend::Default {
         my $s := $source;
         my $grammar;
         my $actions;
-        if %adverbs<transcode> {
-            $s := $!backend.apply_transcodings($s, %adverbs<transcode>);
-        }
         my $outer_ctx := %adverbs<outer_ctx>;
         if nqp::existskey(%adverbs, 'grammar') {
             $grammar := %adverbs<grammar>;

--- a/src/NQP/Compiler.nqp
+++ b/src/NQP/Compiler.nqp
@@ -52,7 +52,7 @@ sub MAIN(*@ARGS) {
 sub MAIN(*@ARGS) {
 #?endif
     # Enter the compiler.
-    $nqpcomp.command_line(@ARGS, :encoding('utf8'), :transcode('ascii iso-8859-1'));
+    $nqpcomp.command_line(@ARGS, :encoding('utf8'));
 
     # Uncomment below to dump cursor usage logging (also need to uncomment two lines
     # in src/QRegex/Cursor.nqp, in !cursor_start_cur and !cursor_start_all).

--- a/src/QRegex/P5Regex/Compiler.nqp
+++ b/src/QRegex/P5Regex/Compiler.nqp
@@ -6,5 +6,5 @@ $p5regex.parsegrammar(QRegex::P5Regex::Grammar);
 $p5regex.parseactions(QRegex::P5Regex::Actions);
 
 sub MAIN(@ARGS) {
-    $p5regex.command_line(@ARGS, :encoding('utf8'), :transcode('ucs4'));
+    $p5regex.command_line(@ARGS, :encoding('utf8'));
 }

--- a/src/QRegex/P6Regex/Compiler.nqp
+++ b/src/QRegex/P6Regex/Compiler.nqp
@@ -6,5 +6,5 @@ $p6regex.parsegrammar(QRegex::P6Regex::Grammar);
 $p6regex.parseactions(QRegex::P6Regex::Actions);
 
 sub MAIN(@ARGS) {
-    $p6regex.command_line(@ARGS, :encoding('utf8'), :transcode('ucs4'));
+    $p6regex.command_line(@ARGS, :encoding('utf8'));
 }

--- a/src/vm/js/HLL/Backend.nqp
+++ b/src/vm/js/HLL/Backend.nqp
@@ -96,10 +96,6 @@ class QASTWithMatch {
 # It can be called HLL::Backend::JavaScript due to problems while merging namespaces
 class JavaScriptBackend {
     has $!compiler;
-
-    method apply_transcodings($s, $transcode) {
-        $s
-    }
     
     method config() {
         nqp::backendconfig()

--- a/src/vm/js/bin/cross-compile.nqp
+++ b/src/vm/js/bin/cross-compile.nqp
@@ -81,6 +81,6 @@ sub MAIN(*@ARGS, *%ARGS) {
         :setting-path('gen/js/stage2'),
         :bootstrap(1),
         :custom-regex-lib('QRegex'),
-        :encoding('utf8'), :transcode('ascii iso-8859-1'));
+        :encoding('utf8'));
 
 }

--- a/src/vm/js/bin/nqp-js.nqp
+++ b/src/vm/js/bin/nqp-js.nqp
@@ -23,5 +23,5 @@ sub MAIN(*@ARGS) {
         :bootstrap(1),
         :custom-regex-lib('QRegex'),
         :no-regex-lib(0),
-        :encoding('utf8'), :transcode('ascii iso-8859-1'));
+        :encoding('utf8'));
 }

--- a/src/vm/jvm/HLL/Backend.nqp
+++ b/src/vm/jvm/HLL/Backend.nqp
@@ -4,10 +4,6 @@ use JASTNodes;
 class HLL::Backend::JVM {
     our %jvm_config   := nqp::backendconfig();
     my $compile_count := 0;
-
-    method apply_transcodings($s, $transcode) {
-        $s
-    }
     
     method config() {
         %jvm_config

--- a/src/vm/moar/HLL/Backend.nqp
+++ b/src/vm/moar/HLL/Backend.nqp
@@ -90,10 +90,6 @@ class HLL::Backend::MoarVM {
         }
     }
 
-    method apply_transcodings($s, $transcode) {
-        $s
-    }
-
     method config() {
         %moar_config
     }


### PR DESCRIPTION
This appears to have only been used by Parrot. Every other backend has their apply_transcodings function in nqp return the original input without any modifications. This change removes the apply transcodings function, and the code that called it.