### PR TITLE
Prevent method calls on nonexistent actions object

### DIFF
--- a/src/QRegex/Cursor.nqp
+++ b/src/QRegex/Cursor.nqp
@@ -602,7 +602,8 @@ role NQPMatchRole is export {
 
     method !reduce(str $name) {
         my $actions := self.actions;
-        my $method := nqp::isnull($actions)
+        # Only call method if the action obj is set (not Mu or Mu-like NQP types)
+        my $method := (nqp::isnull($actions) || !nqp::istype($actions, Any))
             ?? nqp::null()
             !! nqp::tryfindmethod($actions, $name);
         $method($actions, self.MATCH) unless nqp::isnull($method);
@@ -611,7 +612,8 @@ role NQPMatchRole is export {
 
     method !reduce_with_match(str $name, str $key, $match) {
         my $actions := self.actions;
-        my $method := nqp::isnull($actions)
+        # Only call method if the action obj is set (not Mu or Mu-like NQP types)
+        my $method := (nqp::isnull($actions) || !nqp::istype($actions, Any))
             ?? nqp::null()
             !! nqp::tryfindmethod($actions, $name);
         $method($actions, $match, $key) unless nqp::isnull($method);


### PR DESCRIPTION
`NQPMatchRole` currently checks if `self.actions` is null and only looks
for and action method if it isn't null.  This works for NQP types, but
not for Raku types (`Grammar`, etc) where an unset actions object is
`Mu` (which is non-null).  As a result, the current code incorrectly
tries to call any methods on `Mu` with matching names as though they
were action methods.  This rarely goes well.

This PR adds a check to see if the `self.actions` does not inherit
from `Any` (that is, is `Mu`) and skips the method on `Mu` action
objects.  (We check for `!nqp::istype($actions, Any)` instead of
`nqp::istype(Mu, $actions)` because the latter errors for some NQP
types).

Fixes rakudo/rakudo#5443