### PR TITLE
Close handle before unlinking

### DIFF
--- a/t/nqp/019-file-ops.t
+++ b/t/nqp/019-file-ops.t
@@ -475,5 +475,6 @@ my sub create_buf($type) {
     my $fh := open($test-file);
     is($fh.get(), 'line 1', 'read from spurted line 1 ok');
     is($fh.get(), 'line 2', 'read from spurted line 2 ok');
+    close($fh);
     nqp::unlink($test-file);
 }


### PR DESCRIPTION
On Windows a file can't be deleted if it is "busy", i.e. if there is an open handle to it. This start failing locally while making some IO changes in MoarVM, although I'm not sure why it hasn't always been failing.

This updates a file deletion test to close the file it is going to unlink before actually trying to unlink it.