### PR TITLE
Add lookup for translating General_Category longnames

### DIFF
--- a/src/QRegex/Cursor.nqp
+++ b/src/QRegex/Cursor.nqp
@@ -1048,7 +1048,9 @@ role NQPMatchRole is export {
     }
 
     method !DELEGATE_ACCEPTS($obj, $arg) {
-        $obj.ACCEPTS($arg) ?? 1 !! 0
+        (my $delegate-override := nqp::findmethod($?CLASS, 'DELEGATE-ACCEPTS'))
+            ?? $delegate-override($?CLASS, $obj, $arg)
+            !! $obj.ACCEPTS($arg) ?? 1 !! 0
     }
 
     method at(int $pos) {


### PR DESCRIPTION
Also fix broken shortnames "L", "M", "N", "P", "S", "Z", and "C".

This fixes R#5486 and R#5372.