### PR TITLE
Draft: Add nqp::getnextcuid

### DIFF
--- a/docs/ops.markdown
+++ b/docs/ops.markdown
@@ -579,7 +579,9 @@ The opcodes are grouped into the following categories:
 [locallifetime](#locallifetime) |
 [setcodename](#setcodename) |
 [setdebugtypename](#setdebugtypename) |
-[takeclosure](#takeclosure)
+[takeclosure](#takeclosure) |
+[getnextcuid](#getnextcuid)
+
 
 # <a id="arithmetic"></a> Arithmetic
 
@@ -3918,3 +3920,8 @@ Intended as a debugging tool only.
 * `takeclosure(Block $innerblock)`
 
 Creates a lexical closure from the block's outer scope.
+
+## getnextcuid
+* `getnextcuid()`
+
+Gets the next cuid by calling QAST::Block.next-cuid

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -476,6 +476,12 @@ QAST::MASTOperations.add_core_op('stmts', -> $qastcomp, $op {
     $qastcomp.as_mast(QAST::Stmts.new( |@($op) ))
 });
 
+QAST::MASTOperations.add_core_op('getnextcuid', -> $qastcomp, $op {
+    $qastcomp.as_mast(
+        QAST::Op.new( :op<callmethod>, :name<next-cuid>,
+            QAST::WVal.new(:value(QAST::Block))));
+});
+
 my sub pre-size-array($qastcomp, $instructionlist, $array_reg, $size) {
     if $size != 1 {
         my $int_reg := $qastcomp.regalloc.fresh_i();


### PR DESCRIPTION
This is a mechanism for HLLs to rationally supply CUIDs at runtime without fear of collision.

I'm presenting it here for discussion as to its utility before I bother with JVM support and a better commit message.