### PR TITLE
Provide better feedback for ambiguous adverb usage

### DIFF
--- a/src/HLL/Grammar.nqp
+++ b/src/HLL/Grammar.nqp
@@ -555,6 +555,13 @@ An operator precedence parser.
     }
 
     method EXPR_reduce(@termstack, @opstack) {
+        # adverb exists without an op! note: @termstack comes in with size 1 for this edge-case
+        self.panic(
+            "Cannot determine the destination for adverb: " ~
+            nqp::atpos(@termstack, 0) ~
+            "\nTry placing parentheses around the desired callsite to disambiguate."
+        ) unless nqp::elems(@opstack);
+
         my $op := nqp::pop(@opstack);
 
         # Give it a fresh capture list, since we'll have assumed it has


### PR DESCRIPTION
This fixes an LTA situation:

    > my %h = :1k; say 1 ~ %h<k>:exists ~ 1
    ===SORRY!===
    MVMArray: Can't pop from an empty array

Now we throw an `X::Syntax::AmbiguousAdverb` exception:

    > my %h = :1k; say 1 ~ %h<k>:exists ~ 1
    ===SORRY!=== Error while compiling -e
    Cannot determine the destination for named argument: :exists
    Try placing parentheses around the desired callsite to disambiguate.

This addresses R#1378.