### PR TITLE
Add is-interactive to HLL::Compiler

### DIFF
--- a/src/HLL/Compiler.nqp
+++ b/src/HLL/Compiler.nqp
@@ -13,6 +13,7 @@ class HLL::Compiler does HLL::Backend::Default {
     has %!cli-options;
     has $!backend;
     has $!save_ctx;
+    has $!repl-mode;
 
     method BUILD() {
         # Backend is set to the default one, by default.
@@ -319,12 +320,13 @@ class HLL::Compiler does HLL::Backend::Default {
                     }
                 }
                 elsif %adverbs<repl-mode> -> $repl-mode {
-                    my $wants-interactive := $repl-mode eq 'interactive'
+                    my $!repl-mode := $repl-mode;
+                    my $is-interactive := ($repl-mode eq 'interactive' || $repl-mode eq 'process' || $repl-mode eq 'tty')
                       ?? 1
-                      !! $repl-mode eq 'non-interactive'
+                      !! ($repl-mode eq 'non-interactive' || $repl-mode eq 'disabled')
                         ?? 0
-                        !! self.panic("Unknown REPL mode '$repl-mode'. Valid values are 'non-interactive' and 'interactive'");
-                    $result := $wants-interactive
+                        !! self.panic("Unknown REPL mode '$repl-mode'. Valid values are 'tty', 'process', and 'disabled'");
+                    $result := $is-interactive
                       ?? self.interactive(|@a, |%adverbs)
                       !! self.evalfiles('-', |%adverbs);
                 }
@@ -814,6 +816,11 @@ class HLL::Compiler does HLL::Backend::Default {
 
     method supports-op($opname) {
         self.backend.supports-op($opname)
+    }
+
+    method repl-mode() {
+        # defaults to tty
+        $!repl-mode // 'tty'
     }
 }
 


### PR DESCRIPTION
This is a first-pass at allowing for refusing to start the REPL when there is no TTY available.

However, my preferred approach would be to nuke this concept of interactive vs non-interactive and replace with the following options for 'repl-mode':

    - tty
    - process
    - disabled

`disabled` is akin to what happens when you run `perl` or `python`, it just sits there waiting for STDIN to complete with an `<EOF>`, then runs the code. It's identical to what `non-interactive` means at the moment.

`tty` is the default and is really only presented to the user for completeness' sake.

`process` is the same as `interactive` except that it explicitly refers to the expectation that STDIN and STDOUT will *not* be TTY. This would resolve the ambiguity that occurs with this patch where `is-interactive` is only set when `interactive` is explictly passed to `repl-mode` regardless of the fact that a regular, default REPL session is also clearly classifiable as interactive.