### PR TITLE
[JVM] Deserialize VMNull as such

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/SerializationReader.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/SerializationReader.java
@@ -598,8 +598,9 @@ public class SerializationReader {
         int elems;
         switch (discrim) {
         case REFVAR_NULL:
-        case REFVAR_VM_NULL:
             return null;
+        case REFVAR_VM_NULL:
+            return Ops.createNull(tc);
         case REFVAR_OBJECT:
             return readObjRef();
         case REFVAR_VM_INT:

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/SerializationWriter.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/SerializationWriter.java
@@ -298,21 +298,25 @@ public class SerializationWriter {
     public void writeRef(SixModelObject ref) {
         /* Work out what kind of thing we have and determine the discriminator. */
         short discrim = 0;
-        if (Ops.isnull(ref) == 1) {
+        if (ref == null) {
+            discrim = REFVAR_NULL;
+        }
+        else if (Ops.isnull(ref) == 1) {
+            /* A real VMNull. */
             discrim = REFVAR_VM_NULL;
         }
         else if (ref.st.REPR instanceof IOHandle) {
             /* Can't serialize handles. */
-            discrim = REFVAR_VM_NULL;
+            discrim = REFVAR_NULL;
         }
         else if (ref.st.REPR instanceof CallCapture) {
             /* This is a hack for Rakudo's sake; it keeps a CallCapture around in
              * the lexpad, for no really good reason. */
-            discrim = REFVAR_VM_NULL;
+            discrim = REFVAR_NULL;
         }
         else if (ref.st.REPR instanceof MultiCache) {
             /* These are re-computed each time. */
-            discrim = REFVAR_VM_NULL;
+            discrim = REFVAR_NULL;
         }
         else if (ref.st.WHAT == tc.gc.BOOTInt) {
             discrim = REFVAR_VM_INT;
@@ -606,7 +610,7 @@ public class SerializationWriter {
             writeHash(st.MethodCache);
         }
         else {
-            outputs[currentBuffer].putShort(REFVAR_VM_NULL);
+            outputs[currentBuffer].putShort(REFVAR_NULL);
         }
         int vtl = st.VTable == null ? 0 : st.VTable.length;
         writeInt(vtl);

--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/P6Opaque.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/P6Opaque.java
@@ -826,7 +826,7 @@ public class P6Opaque extends REPR {
                     i == REPRData.unboxStrSlot || i == REPRData.unboxObjSlot;
             info.posDelegate = i == REPRData.posDelSlot;
             info.assDelegate = i == REPRData.assDelSlot;
-            info.hasAutoVivContainer = REPRData.autoVivContainers[i] != null;
+            info.hasAutoVivContainer = Ops.isnull(REPRData.autoVivContainers[i]) == 0;
             attrInfoList.add(info);
         }
         if (numAttributes > 0) {

--- a/t/serialization/01-basic.t
+++ b/t/serialization/01-basic.t
@@ -1,4 +1,4 @@
-plan(1518);
+plan(1519);
 
 {
     my $sc := nqp::createsc('exampleHandle');
@@ -134,6 +134,7 @@ sub fresh_out_sc() {
         has int $!a;
         has num $!b;
         has str $!c;
+        has     $!d;
         method new() {
             my $obj := nqp::create(self);
             $obj.BUILD();
@@ -143,10 +144,12 @@ sub fresh_out_sc() {
             $!a := 42;
             $!b := 6.9;
             $!c := 'llama';
+            $!d := nqp::null;
         }
         method a() { $!a }
         method b() { $!b }
         method c() { $!c }
+        method d() { $!d }
     }
     my $v := T4.new();
     add_to_sc($sc, 0, $v);
@@ -162,6 +165,7 @@ sub fresh_out_sc() {
     ok(nqp::scgetobj($dsc, 0).a == 42,                   'P6int attribute has correct value');
     ok(nqp::scgetobj($dsc, 0).b == 6.9,                  'P6num attribute has correct value');
     ok(nqp::scgetobj($dsc, 0).c eq 'llama',              'P6str attribute has correct value');
+    ok(nqp::isnull(nqp::scgetobj($dsc, 0).d),            'attribute with value nqp::null unchanged');
 }
 
 # Serializing an SC with P6opaues and circular references


### PR DESCRIPTION
The old deserialization code gave back a Java null when it encountered a VMNull. This led to problems when compiling Rakudo's settings: Class attributes that were initialized to nqp::null ended up as NQPMu.

Fixes https://github.com/Raku/nqp/issues/828.