### PR TITLE
[JVM] Fix nqp::attrinited for attribute set to null

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/P6Opaque.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/sixmodel/reprs/P6Opaque.java
@@ -475,10 +475,7 @@ public class P6Opaque extends REPR {
                 isInitVisitor.visitLabel(isInitLabels[i]);
                 isInitVisitor.visitVarInsn(Opcodes.ALOAD, 0);
                 isInitVisitor.visitFieldInsn(Opcodes.GETFIELD, className, field, desc);
-                isInitVisitor.visitMethodInsn(Opcodes.INVOKESTATIC, "org/raku/nqp/runtime/Ops", "isnull", "(Lorg/raku/nqp/sixmodel/SixModelObject;)J");
-                isInitVisitor.visitInsn(Opcodes.LCONST_1);
-                isInitVisitor.visitInsn(Opcodes.LCMP);
-                isInitVisitor.visitJumpInsn(Opcodes.IFEQ, isInitNull);
+                isInitVisitor.visitJumpInsn(Opcodes.IFNULL, isInitNull);
                 isInitVisitor.visitInsn(Opcodes.ICONST_1);
                 isInitVisitor.visitInsn(Opcodes.I2L);
                 isInitVisitor.visitInsn(Opcodes.LRETURN);

--- a/t/serialization/01-basic.t
+++ b/t/serialization/01-basic.t
@@ -498,7 +498,7 @@ sub fresh_out_sc() {
     ok(nqp::atpos_i($matching, 0) == 11,"...and we get the right fate");
 }
 
-# nqp::attrinitied works after serialization
+# nqp::attrinited works after serialization
 {
     my $sc := nqp::createsc(fresh_in_sc());
     my $sh := nqp::list_s();
@@ -531,16 +531,9 @@ sub fresh_out_sc() {
     nqp::deserialize($serialized, $dsc, $sh, nqp::list(), nqp::null());
 
     ok(nqp::attrinited(nqp::scgetobj($dsc, 0), TestAttrinitied, '$!written'), 'nqp::attrinited on an attribute that has been written to');
-    ok(!nqp::attrinited(nqp::scgetobj($dsc, 0), TestAttrinitied, '$!not_inited'), 'nqp::attinitied on an attribute that has not be initialized');
+    ok(!nqp::attrinited(nqp::scgetobj($dsc, 0), TestAttrinitied, '$!not_inited'), 'nqp::attrinited on an attribute that has not be initialized');
     ok(nqp::attrinited(nqp::scgetobj($dsc, 0), TestAttrinitied, '$!read'), 'nqp::attrinited on an attribute that has been autovivified');
-
-    if nqp::getcomp('nqp').backend.name eq 'jvm' {
-        skip('null handling is broken on the jvm', 1);
-    }
-    else {
-        ok(nqp::attrinited(nqp::scgetobj($dsc, 0), TestAttrinitied, '$!null'), 'nqp::attrinited on an attribute that has been set with null');
-    }
-
+    ok(nqp::attrinited(nqp::scgetobj($dsc, 0), TestAttrinitied, '$!null'), 'nqp::attrinited on an attribute that has been set with null');
 }
 
 # Serializing an SC with a VMArray


### PR DESCRIPTION
It was wrong to use nqp::isnull for this check with ba4dc47799. An attribute that has been set to nqp::null is still initialized.