### PR TITLE
[JVM] Restore size of curlonglit array

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/runtime/ThreadContext.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/runtime/ThreadContext.java
@@ -122,7 +122,7 @@ public class ThreadContext {
 
     // odds and ends for nqp
     IntArrayList fates = new IntArrayList(), curst = new IntArrayList(), nextst = new IntArrayList();
-    long[] curlonglit = new long[100];
+    long[] curlonglit = new long[200];
 
     public ThreadContext(GlobalContext gc) {
         this.gc = gc;


### PR DESCRIPTION
This was reduced in https://github.com/Raku/nqp/commit/f02dbe4c9b, but I'm now seeing ArrayIndexOutOfBoundsExceptions in a variety of spectests.

One evaluation that died with this error was the following (from roast's S07-slip/slip.t):

  my \a = 0, ([\+] 1..*).Slip

I played a bit and that one started to pass with a size of 120. But it feels sensible to have some buffer and since I never saw this problem before, I just went for the old value.