### PR TITLE
[JVM] Return exit code for run failure

### DIFF
--- a/src/vm/jvm/runtime/org/raku/nqp/io/AsyncProcessHandle.java
+++ b/src/vm/jvm/runtime/org/raku/nqp/io/AsyncProcessHandle.java
@@ -82,8 +82,9 @@ public class AsyncProcessHandle implements IIOClosable {
                 SixModelObject message = boxError(t.toString());
 
                 SixModelObject error = config.get("error");
+                /* Return exception message and hard-coded exit code -1. */
                 if (Ops.isnull(error) == 0)
-                    send(error, message);
+                    send(error, message, boxInt(-1 << 8));
 
                 SixModelObject stdoutBytes = config.get("stdout_bytes");
                 if (Ops.isnull(stdoutBytes) == 0)


### PR DESCRIPTION
This adjusts the behaviour of the JVM backend to the change from https://github.com/rakudo/rakudo/commit/81c7064ba7. The error callback now accepts a second argument with an exit code.

At least for IOExceptions the original error code from the JVM can be seen in the error message. I don't see a real benefit in extracting that error code and passing it on. Instead, we'll just set the exit code to -1 (which is also expected by at least one spectest: https://github.com/Raku/roast/blob/3032bcf423/S29-os/system.t#L47).