### PR TITLE
Serialize precomputed grammar NFAs in their VM form

### DIFF
--- a/src/QRegex/Cursor.nqp
+++ b/src/QRegex/Cursor.nqp
@@ -849,7 +849,7 @@ role NQPMatchRole is export {
           self, "!protoregex_table", { self."!protoregex_table"() }
         );
         for %protorx {
-            self.HOW.cache(self, $_.key, { self.'!protoregex_nfa'($_.key) });
+            self.HOW.cache(self, $_.key, { self.'!protoregex_nfa'($_.key).precompute });
         }
 
         # Pre-compute all the alternation NFAs.
@@ -857,7 +857,7 @@ role NQPMatchRole is export {
             if nqp::can($method, 'ALT_NFAS') {
                 for $method.ALT_NFAS -> $name {
                     self.HOW.cache(
-                       self, ~$name, { self.'!alt_nfa'($method, $name.key) }
+                       self, ~$name, { self.'!alt_nfa'($method, $name.key).precompute }
                     );
                 }
             }

--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -1028,31 +1028,42 @@ class QRegex::NFA {
     # NFA type.
     my knowhow NFAType is repr('NFA') { }
 
+    # A precomputed NFA carries only its fates list, so reaching here
+    # without a VM-level NFA means it was lost, not never built.
+    method !build_nfa_object() {
+        nqp::die('Precomputed NFA lost its VM-level NFA object')
+          if nqp::elems(@!states) < 2;
+
+#        self.mydump() if $nfadeb;
+
+        nqp::scwbdisable();
+        $!nfa_object := nqp::nfafromstatelist(@!states, NFAType);
+        nqp::scwbenable();
+    }
+
     method run(str $target, int $offset) {
-        unless nqp::isconcrete($!nfa_object) {
-
-#            self.mydump() if $nfadeb;
-
-            nqp::scwbdisable();
-            $!nfa_object := nqp::nfafromstatelist(@!states, NFAType);
-            nqp::scwbenable();
-        }
+        self.'!build_nfa_object'() unless nqp::isconcrete($!nfa_object);
 
         nqp::nfarunproto($!nfa_object, $target, $offset)
     }
 
     method run_alt(str $target, int $offset, $bstack, $cstack, @labels) {
-
-        unless nqp::isconcrete($!nfa_object) {
-
-#            self.mydump() if $nfadeb;
-
-            nqp::scwbdisable();
-            $!nfa_object := nqp::nfafromstatelist(@!states, NFAType);
-            nqp::scwbenable();
-        }
+        self.'!build_nfa_object'() unless nqp::isconcrete($!nfa_object);
 
         nqp::nfarunalt($!nfa_object, $target, $offset, $bstack,$cstack, @labels)
+    }
+
+    # Build the VM-level NFA eagerly and keep only element zero of the
+    # build-time state graph, which !protoregex reads to map a fate back
+    # to its rule name. !precompute_nfas calls this while a grammar is
+    # being compiled, so the compact form is what gets serialized.
+    method precompute() {
+        unless nqp::isconcrete($!nfa_object) {
+            $!nfa_object := nqp::nfafromstatelist(@!states, NFAType);
+        }
+        @!states := nqp::list(nqp::atpos(@!states, 0));
+        $!known  := nqp::null;
+        self
     }
 
     method generic() { $!generic }


### PR DESCRIPTION
Previously a grammar's precomputed protoregex and alternation NFAs were serialized as QRegex::NFA objects still holding the full nested statelist they were built from, with each edge as three boxed ints in an NQPArray per state. The VM-level NFA object was only built on first use, and the statelist stayed reachable from the HOW cache forever. For a bare `raku -e ''` under RakuAST this was 148k NQPArrays and 371k boxed ints, 24.6MB of a 60MB heap.

This builds the VM-level NFA when the grammar precomputes it and keeps only the fates list of the statelist, which is still needed to map a fate back to its rule name. The NFA REPR serializes natively, so the compiled grammar carries the compact form. `raku -e ''` drops from 126MB to 103MB RSS and Perl6::Grammar and Raku::Grammar each shrink from 5.9MB to 3.7MB on disk.