### PR TITLE
Give a block reference the frame of its own compilation

### DIFF
--- a/src/vm/moar/QAST/QASTCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTCompilerMAST.nqp
@@ -10,6 +10,10 @@ my class MASTCompilerInstance {
     # MAST frames lookup hash.
     has %!mast_frames;
 
+    # Frames a block reference created ahead of the block's own
+    # compilation, keyed by cuid, until that compilation fills them in.
+    has %!pending_frames;
+
     # The filename we're compiling.
     has $!file;
 
@@ -375,6 +379,7 @@ my class MASTCompilerInstance {
         );
         $!writer.set-compunit($!mast_compunit);
         %!mast_frames := %moar<mast_frames>;
+        %!pending_frames := nqp::hash();
         $!file := nqp::ifnull(nqp::getlexdyn('$?FILES'), "<unknown file>");
         $!sc := NQPMu;
 
@@ -386,6 +391,22 @@ my class MASTCompilerInstance {
 
         # Compile, and evaluate to compilation unit.
         self.as_mast($qast);
+
+        # A reference to a block this unit never compiled would leave an
+        # empty frame standing in for the block.
+        if nqp::elems(%!pending_frames) {
+            my @missing;
+            for sorted_keys(%!pending_frames) -> $cuid {
+                my $name := %!pending_frames{$cuid}[0].name;
+                my $from := %!pending_frames{$cuid}[1];
+                my $desc := "cuid " ~ $cuid;
+                $desc := $desc ~ " '" ~ $name ~ "'" if $name;
+                $desc := $desc ~ " referenced from '" ~ $from ~ "'" if $from;
+                nqp::push(@missing, $desc);
+            }
+            nqp::die("QAST::Block with " ~ nqp::join(", ", @missing)
+                ~ " has not appeared in " ~ $!file);
+        }
 
         # write back our frames to the outer compiler
         if nqp::elems(%moar<frames>) {
@@ -974,14 +995,22 @@ my class MASTCompilerInstance {
         else {
             my $outer_frame := $!mast_frame;
 
-            # Create an empty frame and add it to the compilation unit.
-            my $frame := MAST::Frame.new(
-                :name($node.name),
-                :cuuid($cuid),
-                :writer($!writer),
-                :compunit($!mast_compunit));
-
-            $!mast_compunit.add_frame($frame);
+            # Take the empty frame a reference to this block created
+            # ahead of it, or create one and add it to the compilation
+            # unit.
+            my $frame;
+            if nqp::existskey(%!pending_frames, $cuid) {
+                $frame := %!pending_frames{$cuid}[0];
+                nqp::deletekey(%!pending_frames, $cuid);
+            }
+            else {
+                $frame := MAST::Frame.new(
+                    :name($node.name),
+                    :cuuid($cuid),
+                    :writer($!writer),
+                    :compunit($!mast_compunit));
+                $!mast_compunit.add_frame($frame);
+            }
             $outer := $*BLOCK;
             $block := BlockInfo.new($node, (nqp::defined($outer) ?? $outer !! NQPMu), self);
             %*BLOCKS_DONE{$cuid} := [$block, $outer];
@@ -2067,12 +2096,37 @@ my class MASTCompilerInstance {
         self.const_s($sv.value)
     }
 
-    multi method compile_node(QAST::BVal $bv, :$want) {
-        my $block := $bv.value;
+    # The frame of this compilation unit for a block. A reference that
+    # precedes the block's own compilation gets an empty frame, which
+    # that compilation fills in. The frame table is shared with the
+    # compilations this one nests and the one it nests in, so an entry
+    # another unit made does not count, and the replacement goes back
+    # into the table. Frames written back from a nested compilation
+    # keep that compilation as their compunit even when they land in
+    # this unit's frame list, so a reference to such a block mints a
+    # replacement too. The replacement dies as never appearing, which
+    # holds as long as code another compilation compiled is bound at
+    # load time instead of referenced by block value.
+    method frame_for_block($block) {
         my $cuid  := $block.cuid();
         my $frame := %!mast_frames{$cuid};
-        nqp::die("QAST::Block with cuid $cuid has not appeared")
-            unless $frame && $frame ~~ MAST::Frame;
+        unless $frame && $frame ~~ MAST::Frame
+                && nqp::eqaddr($frame.compunit, $!mast_compunit) {
+            $frame := MAST::Frame.new(
+                :name($block.name),
+                :cuuid($cuid),
+                :writer($!writer),
+                :compunit($!mast_compunit));
+            $!mast_compunit.add_frame($frame);
+            %!mast_frames{$cuid} := $frame;
+            %!pending_frames{$cuid} :=
+                [$frame, $!mast_frame ?? $!mast_frame.name !! ''];
+        }
+        $frame
+    }
+
+    multi method compile_node(QAST::BVal $bv, :$want) {
+        my $frame := self.frame_for_block($bv.value);
 
         my $reg := $!regalloc.fresh_o();
         MAST::Op.new(:frame($!mast_frame),

--- a/t/qast/01-qast.t
+++ b/t/qast/01-qast.t
@@ -1,6 +1,6 @@
 use QAST;
 
-plan(178);
+plan(181);
 
 # Following a test infrastructure.
 sub compile_qast($qast) {
@@ -92,6 +92,37 @@ is_qast(
     ),
     666,
     'BVal node');
+
+my $late_block := QAST::Block.new( QAST::IVal.new( :value(555) ) );
+is_qast(
+    QAST::Block.new(
+        QAST::Stmts.new( :resultchild(0),
+            QAST::Op.new(
+                :op('call'),
+                QAST::BVal.new( :value($late_block) )
+            ),
+            $late_block
+        )
+    ),
+    555,
+    'BVal node preceding its block');
+
+{
+    my $orphan := QAST::Block.new( QAST::IVal.new( :value(1) ) );
+    my $error := '';
+    try {
+        compile_qast(QAST::Block.new(
+            QAST::Op.new(
+                :op('call'),
+                QAST::BVal.new( :value($orphan) )
+            )
+        ));
+        CATCH { $error := nqp::getmessage($_) }
+    }
+    ok($error ne '', 'a BVal for a block the unit never compiles fails to compile');
+    ok(nqp::index($error, 'has not appeared') >= 0,
+        'the missing block error says the block has not appeared');
+}
 
 is_qast(
     QAST::Block.new(


### PR DESCRIPTION
Previously a QAST::BVal took whatever frame the shared frame table held for the block's cuid. A compilation nested in another writes its frames into that table too, so a reference compiled ahead of the block in the outer unit resolved to the nested compilation's frame, whose index names an unrelated frame of the outer unit. A reference ahead of a block that no compilation had seen yet died instead.

This has a block reference take the frame this unit made for the block, making an empty one when the reference precedes the block's own compilation, which then fills it in. A frame still empty at the end of the unit reports the block as never having appeared, now from the end of the unit rather than from the reference.