### PR TITLE
Let a block reference resolve to a frame written back into the unit

### DIFF
--- a/src/vm/moar/QAST/QASTCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTCompilerMAST.nqp
@@ -14,6 +14,16 @@ my class MASTCompilerInstance {
     # compilation, keyed by cuid, until that compilation fills them in.
     has %!pending_frames;
 
+    # Set once the unit's own tree is compiled, after which no block of
+    # that tree is still to be compiled by this unit. A frame table entry
+    # another compilation made for a referenced block then no longer
+    # waits on this unit compiling the block itself.
+    has int $!tree_compiled;
+
+    # The frames this unit's frame list held before its own compilation
+    # added any, keyed by object id, built on first use.
+    has %!held_frames;
+
     # The filename we're compiling.
     has $!file;
 
@@ -380,6 +390,8 @@ my class MASTCompilerInstance {
         $!writer.set-compunit($!mast_compunit);
         %!mast_frames := %moar<mast_frames>;
         %!pending_frames := nqp::hash();
+        $!tree_compiled := 0;
+        %!held_frames := nqp::null();
         $!file := nqp::ifnull(nqp::getlexdyn('$?FILES'), "<unknown file>");
         $!sc := NQPMu;
 
@@ -828,6 +840,7 @@ my class MASTCompilerInstance {
 
         # Compile the block
         self.as_mast($cu[0]);
+        $!tree_compiled := 1;
 
         # If we are in compilation mode, or have pre-deserialization or
         # post-deserialization tasks, handle those. Overall, the process
@@ -2099,19 +2112,23 @@ my class MASTCompilerInstance {
     # The frame of this compilation unit for a block. A reference that
     # precedes the block's own compilation gets an empty frame, which
     # that compilation fills in. The frame table is shared with the
-    # compilations this one nests and the one it nests in, so an entry
-    # another unit made does not count, and the replacement goes back
-    # into the table. Frames written back from a nested compilation
-    # keep that compilation as their compunit even when they land in
-    # this unit's frame list, so a reference to such a block mints a
-    # replacement too. The replacement dies as never appearing, which
-    # holds as long as code another compilation compiled is bound at
-    # load time instead of referenced by block value.
+    # compilations this one nests and the one it nests in. While this
+    # unit may still compile the block itself, an entry another unit
+    # made does not stand in for that, and the replacement goes back
+    # into the table. Once the unit's tree is compiled no such
+    # compilation is left to come, and the entry serves if the other
+    # compilation wrote the frame back into this unit's frame list,
+    # which is how code compiled while the unit was being compiled gets
+    # into its bytecode. Such a frame keeps the frame indexes its own
+    # compilation gave its bytecode, so what it references at run time
+    # is only right where those line up with this unit's. A replacement
+    # nothing fills dies as never appearing.
     method frame_for_block($block) {
         my $cuid  := $block.cuid();
         my $frame := %!mast_frames{$cuid};
         unless $frame && $frame ~~ MAST::Frame
-                && nqp::eqaddr($frame.compunit, $!mast_compunit) {
+                && (nqp::eqaddr($frame.compunit, $!mast_compunit)
+                    || $!tree_compiled && self.holds_frame($frame)) {
             $frame := MAST::Frame.new(
                 :name($block.name),
                 :cuuid($cuid),
@@ -2123,6 +2140,19 @@ my class MASTCompilerInstance {
                 [$frame, $!mast_frame ?? $!mast_frame.name !! ''];
         }
         $frame
+    }
+
+    # Whether the frame is in this unit's frame list. Only a frame from
+    # another compilation is asked about, and every such frame was in the
+    # list before this unit added its own, so the index is built once.
+    method holds_frame($frame) {
+        if nqp::isnull(%!held_frames) {
+            %!held_frames := nqp::hash();
+            for nqp::getattr($!mast_compunit, MAST::CompUnit, '@!frames') {
+                %!held_frames{nqp::objectid($_)} := 1;
+            }
+        }
+        nqp::existskey(%!held_frames, nqp::objectid($frame))
     }
 
     multi method compile_node(QAST::BVal $bv, :$want) {

--- a/src/vm/moar/QAST/QASTOperationsMAST.nqp
+++ b/src/vm/moar/QAST/QASTOperationsMAST.nqp
@@ -614,9 +614,7 @@ QAST::MASTOperations.add_core_op('list_b', -> $qastcomp, $op {
         for $op.list {
             nqp::die("The 'list_b' op needs a list of blocks, got " ~ $_.HOW.name($_))
                 unless nqp::istype($_, QAST::Block);
-            my $cuid  := $_.cuid();
-            my $frame := $qastcomp.mast_frames{$cuid};
-            getcode_op($mast_frame, $item_reg, $frame);
+            getcode_op($mast_frame, $item_reg, $qastcomp.frame_for_block($_));
             push_o_op($mast_frame, $arr_reg, $item_reg);
         }
         $regalloc.release_register($item_reg, nqp::const::MVM_reg_obj);

--- a/t/qast/01-qast.t
+++ b/t/qast/01-qast.t
@@ -1,6 +1,6 @@
 use QAST;
 
-plan(181);
+plan(184);
 
 # Following a test infrastructure.
 sub compile_qast($qast) {
@@ -122,6 +122,88 @@ is_qast(
     ok($error ne '', 'a BVal for a block the unit never compiles fails to compile');
     ok(nqp::index($error, 'has not appeared') >= 0,
         'the missing block error says the block has not appeared');
+}
+
+{
+    # A compilation run while a unit is being compiled writes its frames
+    # back into that unit's frame list. Code the unit adds after its own
+    # tree may reference such a block. start opens the frame list a unit
+    # compile would, so the compile that follows writes its frames into
+    # the unit compiled from it.
+    my $backend := nqp::getcomp('nqp').backend;
+    my %*COMPILING := nqp::hash();
+    $backend.start(NQPMu);
+    my $shared := QAST::Block.new( :name('shared'), QAST::IVal.new( :value(777) ) );
+    compile_qast(QAST::Block.new(
+        QAST::Op.new( :op('call'), QAST::BVal.new( :value($shared) ) ),
+        $shared
+    ));
+    my $unit := QAST::CompUnit.new(
+        :hll('nqp'),
+        :post_deserialize([
+            QAST::Op.new(
+                :op('bindcurhllsym'),
+                QAST::SVal.new( :value('written-back-block') ),
+                QAST::Op.new( :op('call'), QAST::BVal.new( :value($shared) ) )
+            )
+        ]),
+        QAST::Block.new( QAST::IVal.new( :value(1) ) )
+    );
+    nqp::getcomp('nqp').compile($backend.mast($unit), :from('mast'));
+    is(nqp::getcurhllsym('written-back-block'), 777,
+        'a BVal after the unit tree resolves to a block another compilation wrote back');
+}
+
+{
+    # The same reference inside the unit's tree waits on the unit's own
+    # compilation of the block, which never comes.
+    my $backend := nqp::getcomp('nqp').backend;
+    my %*COMPILING := nqp::hash();
+    $backend.start(NQPMu);
+    my $shared := QAST::Block.new( :name('shared'), QAST::IVal.new( :value(777) ) );
+    compile_qast(QAST::Block.new(
+        QAST::Op.new( :op('call'), QAST::BVal.new( :value($shared) ) ),
+        $shared
+    ));
+    my $error := '';
+    try {
+        $backend.mast(QAST::CompUnit.new(
+            :hll('nqp'),
+            QAST::Block.new( QAST::Op.new( :op('call'), QAST::BVal.new( :value($shared) ) ) )
+        ));
+        CATCH { $error := nqp::getmessage($_) }
+    }
+    ok(nqp::index($error, "'shared' has not appeared") >= 0,
+        'a BVal inside the unit tree for a block only another compilation compiled fails to compile');
+}
+
+{
+    # A frame another compilation made that is not in this unit's frame
+    # list does not serve after the tree either. The second start opens a
+    # fresh frame list for the unit, so the first compile's frames stay in
+    # the shared table but out of the unit's list.
+    my $backend := nqp::getcomp('nqp').backend;
+    my %*COMPILING := nqp::hash();
+    $backend.start(NQPMu);
+    my $foreign := QAST::Block.new( :name('foreign'), QAST::IVal.new( :value(888) ) );
+    compile_qast(QAST::Block.new(
+        QAST::Op.new( :op('call'), QAST::BVal.new( :value($foreign) ) ),
+        $foreign
+    ));
+    $backend.start(NQPMu);
+    my $error := '';
+    try {
+        $backend.mast(QAST::CompUnit.new(
+            :hll('nqp'),
+            :post_deserialize([
+                QAST::Op.new( :op('call'), QAST::BVal.new( :value($foreign) ) )
+            ]),
+            QAST::Block.new( QAST::IVal.new( :value(1) ) )
+        ));
+        CATCH { $error := nqp::getmessage($_) }
+    }
+    ok(nqp::index($error, "'foreign' referenced from") >= 0 && nqp::index($error, 'has not appeared') >= 0,
+        'a BVal after the unit tree for a frame this unit does not hold fails to compile');
 }
 
 is_qast(


### PR DESCRIPTION
Previously a block reference took a frame from the shared frame table only when this compilation made it. A compilation run while a unit is being compiled writes its frames back into that unit's frame list, and the unit's deserialization code references such blocks by value, so a module compiled under the legacy frontend that compiles Raku code at BEGIN time died with the block never having appeared.

This accepts a frame another compilation made once the unit's own tree is compiled, provided the frame sits in this unit's frame list. A reference inside the tree keeps getting an empty frame for the unit's own compilation of the block to fill in.