### PR TITLE
Recompute block quantifier limits after a cursor restart

### DIFF
--- a/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
@@ -144,6 +144,11 @@ class QAST::MASTRegexCompiler {
     # Jump table.
     has @!rxjumps;
 
+    # One register per dynquant, set once the regex frame has computed
+    # that quantifier's limits. Collected so the restart label can clear
+    # them all rather than relying on a fresh frame starting zeroed.
+    has @!limits_done_regs;
+
     # Do we use the cursor stack?
     has int $!cstack_used;
 
@@ -264,6 +269,7 @@ class QAST::MASTRegexCompiler {
         );
 
         @!rxjumps := nqp::list($donelabel);
+        @!limits_done_regs := nqp::list();
 
         my $shared := $!regalloc.fresh_o();
         my $itmp := $!regalloc.fresh_i();
@@ -323,6 +329,9 @@ class QAST::MASTRegexCompiler {
         $itmp := $!regalloc.fresh_i();
         my $i18 := $!regalloc.fresh_i();
         $frame.add-label($restartlabel);
+        for @!limits_done_regs {
+            op($frame, 'set', $_, $zero);
+        }
         if $!cstack_used {
             op($frame, 'getattr_o', $cstack, $cur, $curclass, sval('$!cstack'),
                 ival(nqp::hintfor($!cursor_type, '$!cstack')));
@@ -926,10 +935,23 @@ class QAST::MASTRegexCompiler {
         my $min_reg    := $!regalloc.fresh_i();
         my $max_reg    := $!regalloc.fresh_i();
 
+        # The limits come from running code, so a backtrack landing in a
+        # restarted frame finds them unset. Such a landing jumps back to
+        # $limitslabel to compute them and then returns to $landlabel.
+        my $limits_done  := $!regalloc.fresh_i();
+        my $from_landing := $!regalloc.fresh_i();
+        my $limitslabel  := label();
+        my $landlabel    := label();
+        nqp::push(@!limits_done_regs, $limits_done);
+
+        op($frame, 'set', $from_landing, %!reg<zero>);
+        $frame.add-label($limitslabel);
         my $minmax_mast := $!qastcomp.as_mast($minmax, :want(nqp::const::MVM_reg_obj));
         my $res_reg     := $minmax_mast.result_reg;
         op($frame, 'atpos_i', $min_reg, $res_reg, %!reg<zero>);
         op($frame, 'atpos_i', $max_reg, $res_reg, %!reg<one>);
+        op($frame, 'set', $limits_done, %!reg<one>);
+        op($frame, 'if_i', $from_landing, $landlabel);
 
         # return if $min == 0 && $max == 0;
         op($frame, 'if_i', $min_reg, $skip8label);
@@ -962,6 +984,10 @@ class QAST::MASTRegexCompiler {
 
             op($frame, 'goto', $seplabel) if $sep;
             $frame.add-label($looplabel);
+            op($frame, 'if_i', $limits_done, $landlabel);
+            op($frame, 'set', $from_landing, %!reg<one>);
+            op($frame, 'goto', $limitslabel);
+            $frame.add-label($landlabel);
             op($frame, 'set', $ireg, $rep);
             if $sep {
                 self.regex_mast($sep);
@@ -1022,6 +1048,10 @@ class QAST::MASTRegexCompiler {
             op($frame, 'goto', $looplabel);
             $frame.add-label($skip5label);         # }
             $frame.add-label($donelabel);
+            op($frame, 'if_i', $limits_done, $landlabel);
+            op($frame, 'set', $from_landing, %!reg<one>);
+            op($frame, 'goto', $limitslabel);
+            $frame.add-label($landlabel);
 
             op($frame, 'le_i', $ireg, $min_reg, %!reg<one>); # if $min > 1 {
             op($frame, 'if_i', $ireg, $skip6label);

--- a/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
@@ -976,11 +976,13 @@ class QAST::MASTRegexCompiler {
             my $seplabel := label();
             op($frame, 'set', $rep, %!reg<zero>);
 
-            op($frame, 'ge_i', $ireg, $min_reg, %!reg<one>); # if $min < 1 {
-            op($frame, 'if_i', $ireg, $skip1label);
+            my $hasmin := $!regalloc.fresh_i();
+            op($frame, 'ge_i', $hasmin, $min_reg, %!reg<one>); # if $min < 1 {
+            op($frame, 'if_i', $hasmin, $skip1label);
             self.regex_mark($looplabel_index, $pos, $rep);
             op($frame, 'goto', $donelabel);
             $frame.add-label($skip1label);                      # }
+            $!regalloc.release_register($hasmin, nqp::const::MVM_reg_int64);
 
             op($frame, 'goto', $seplabel) if $sep;
             $frame.add-label($looplabel);

--- a/t/nqp/034-rxcodeblock.t
+++ b/t/nqp/034-rxcodeblock.t
@@ -1,4 +1,4 @@
-plan(21);
+plan(23);
 
 grammar ABC {
     token TOP { { ok(1, 'basic code assertion'); } }
@@ -53,6 +53,8 @@ grammar DynQuant {
     regex frugal3 { (a **? {[1,3]}) c }
     regex two     { (x ** {2} . ** {2})+ n }
     regex sep     { (<[a..z]> ** {2} % ',') ',b' }
+    regex sepex   { (a **? {2} % ',') $ }
+    regex seprng  { (a **? {[1,3]} % ',') ',c' }
 }
 sub caps($m) {
     return 'no match' unless $m;
@@ -63,7 +65,7 @@ sub caps($m) {
     nqp::join(",", @s)
 }
 if nqp::getcomp('nqp').backend.name ne 'moar' {
-    skip('block quantifier limits are lost on restart', 8);
+    skip('block quantifier limits are lost on restart', 10);
 }
 else {
     ok( !DynQuant.parse('burden'),
@@ -82,4 +84,8 @@ else {
         'backtracking into a capture keeps the limits of each block quantifier in it');
     ok( !DynQuant.parse('a,b', :rule<sep>),
         'backtracking into a capture keeps the block quantifier count with a separator');
+    is( caps(DynQuant.parse('a,a', :rule<sepex>)), 'a,a',
+        'frugal block quantifier with a separator counts its first repetition once');
+    is( caps(DynQuant.parse('a,a,a,c', :rule<seprng>)), 'a,a,a',
+        'frugal block quantifier with a separator grows to its maximum when backtracked into');
 }

--- a/t/nqp/034-rxcodeblock.t
+++ b/t/nqp/034-rxcodeblock.t
@@ -1,4 +1,4 @@
-plan(13);
+plan(21);
 
 grammar ABC {
     token TOP { { ok(1, 'basic code assertion'); } }
@@ -38,3 +38,48 @@ grammar SeeCursor {
     }
 }
 SeeCursor.parse('abc');
+
+# A block quantifier inside a subrule computes its limits when the
+# subrule runs. Backtracking into that subrule restarts it, and the
+# restarted subrule must honor the same limits.
+my $n := 2;
+grammar DynQuant {
+    regex TOP     { (. ** {2})+ n }
+    regex range   { (. ** {[2,3]})+ n }
+    regex lexical { (. ** {$n})+ n }
+    regex named   { <pair>+ n }
+    regex pair    { . ** {2} }
+    regex frugal  { (a **? {[1,2]}) c }
+    regex frugal3 { (a **? {[1,3]}) c }
+    regex two     { (x ** {2} . ** {2})+ n }
+    regex sep     { (<[a..z]> ** {2} % ',') ',b' }
+}
+sub caps($m) {
+    return 'no match' unless $m;
+    my $c := $m[0];
+    return ~$c unless nqp::islist($c);
+    my @s;
+    for $c { nqp::push(@s, ~$_) }
+    nqp::join(",", @s)
+}
+if nqp::getcomp('nqp').backend.name ne 'moar' {
+    skip('block quantifier limits are lost on restart', 8);
+}
+else {
+    ok( !DynQuant.parse('burden'),
+        'backtracking into a capture keeps the block quantifier exact count');
+    is( caps(DynQuant.parse('abcdn', :rule<range>)), 'ab,cd',
+        'backtracking into a capture keeps the block quantifier minimum');
+    ok( !DynQuant.parse('burden', :rule<lexical>),
+        'backtracking into a capture keeps a lexical block quantifier count');
+    ok( !DynQuant.parse('burden', :rule<named>),
+        'backtracking into a named subrule keeps the block quantifier exact count');
+    ok( !DynQuant.parse('aaac', :rule<frugal>),
+        'frugal block quantifier stops at its maximum when backtracked into');
+    is( caps(DynQuant.parse('aaac', :rule<frugal3>)), 'aaa',
+        'frugal block quantifier grows up to its maximum when backtracked into');
+    ok( !DynQuant.parse('xxan', :rule<two>),
+        'backtracking into a capture keeps the limits of each block quantifier in it');
+    ok( !DynQuant.parse('a,b', :rule<sep>),
+        'backtracking into a capture keeps the block quantifier count with a separator');
+}


### PR DESCRIPTION
A `** {code}` quantifier evaluates its limits when the regex reaches it and keeps them in frame registers. Backtracking into a subrule restarts its frame, which jumps straight to the pending mark without passing that code, so the landing saw a min and max of zero and accepted any repetition count.

```
$ raku -e 'say "burden" ~~ /(. ** {2})+ n/'
｢burden｣
 0 => ｢bu｣
 0 => ｢rd｣
 0 => ｢e｣
```

This shows up anywhere a cursor holding such a quantifier gets restarted: captures, named regexes, `:ex` matching, and frugal `**?` quantifiers overrunning their maximum. `[...]` groups never showed it since they inline into the same frame, and `token` never backtracks in.

The first commit records per quantifier whether the frame computed its limits, clears those on restart, and has a landing that finds them clear jump back to compute the limits before continuing. That exposed a second problem: the frugal branch tested `min < 1` into the register carrying the repetition count, and with a `%` separator the entry path skips the store that resets it, so the first repetition counted as two. The second commit gives that test its own register.

Tests are gated to MoarVM since the JVM and JS regex compilers behave the same way on restart.

Fixes rakudo/rakudo#5588
