### PR TITLE
Drop the cached match when backtracking trims captures

### DIFF
--- a/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
@@ -235,6 +235,7 @@ class QAST::MASTRegexCompiler {
         my $back_cur := $!regalloc.fresh_o();
         my $method   := $!regalloc.fresh_o();
         my $tmp      := $!regalloc.fresh_o();
+        my $nullreg  := $!regalloc.fresh_o();
 
         # create our labels
         my $startlabel   := label();
@@ -376,7 +377,16 @@ class QAST::MASTRegexCompiler {
             op($frame, 'dec_i', $i18);
             op($frame, 'atpos_i', $i18, $bstack, $i18);
             $frame.add-label($cutlabel);
+            # When the trim shortens the stack, a MATCH built before it
+            # describes captures that are no longer there, so drop the
+            # cursor's cached one.
+            op($frame, 'elems', $i0, $cstack);
+            op($frame, 'le_i', $i0, $i0, $i18);
+            op($frame, 'if_i', $i0, $jumplabel);
             op($frame, 'setelemspos', $cstack, $i18);
+            op($frame, 'null', $nullreg);
+            op($frame, 'bindattr_o', $cur, $curclass, sval('$!match'), $nullreg,
+                ival(nqp::hintfor($!cursor_type, '$!match')));
         }
         $frame.add-label($jumplabel);
         op($frame, 'jumplist', ival(+@!rxjumps), $itmp);

--- a/t/nqp/034-rxcodeblock.t
+++ b/t/nqp/034-rxcodeblock.t
@@ -1,4 +1,4 @@
-plan(23);
+plan(27);
 
 grammar ABC {
     token TOP { { ok(1, 'basic code assertion'); } }
@@ -88,4 +88,32 @@ else {
         'frugal block quantifier with a separator counts its first repetition once');
     is( caps(DynQuant.parse('a,a,a,c', :rule<seprng>)), 'a,a,a',
         'frugal block quantifier with a separator grows to its maximum when backtracked into');
+}
+
+# Backtracking drops captures from the stack, and a code block that runs
+# afterwards must see only the captures that remain.
+my @seen;
+my @empty;
+my @alt;
+grammar Trimmed {
+    regex TOP   { (\w)+ { nqp::push(@seen, ~nqp::elems($/[0])) } bc }
+    regex tail  { (\w)+ <?{ my @c := $/[0]; ~@c[nqp::elems(@c) - 1] eq 'b' }> }
+    regex empty { (\w)* { nqp::push(@empty, ~nqp::elems($/[0])) } a }
+    regex alt   { [ (a) b | a ] { nqp::push(@alt, ~nqp::defined($/[0])) } b }
+}
+if nqp::getcomp('nqp').backend.name ne 'moar' {
+    skip('captures stay in the match after backtracking', 4);
+}
+else {
+    Trimmed.parse('abc');
+    is( nqp::join(',', @seen), '3,2,1',
+        'a code block sees only the captures left after backtracking');
+    is( ~Trimmed.parse('abc', :rule<tail>), 'ab',
+        'an assertion sees only the captures left after backtracking');
+    Trimmed.parse('ab', :rule<empty>);
+    is( nqp::join(',', @empty), '2,1,0',
+        'a code block sees no captures after backtracking drops them all');
+    Trimmed.parse('ab', :rule<alt>);
+    is( nqp::join(',', @alt), '1,0',
+        'a code block sees no capture after backtracking into another alternative');
 }


### PR DESCRIPTION
A code block binds `$/` to the cursor's MATCH, which reifies the capture stack once and is then reused. Pushing a capture already discards that cache, but trimming captures on backtrack did not, so a later code block or assertion saw captures the regex had backtracked past. Previously `'abc' ~~ /(\w)+ <?{ $0.tail eq 'b' }>/` could never match.

This discards the cached match whenever the fail path shortens the capture stack.

Fixes rakudo/rakudo#4105