### PR TITLE
Give each repetition of a bounded quantifier its own NFA state

### DIFF
--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -660,46 +660,44 @@ class QRegex::NFA {
 
         if $max > 1 || $min > 1 {
             my int $count;
-            my int $state := -1;
+            my int $state;
             my int $has_sep := nqp::defined($node1);
 
+            # Land each repetition on its own state. Landing on $to would
+            # start the next repetition from the caller's exit, and for the
+            # last atom of a regex that exit is state 0, the fate list.
             while $count < $max || $count < $min {
                 if $count >= $min {
                     $state := self.addedge(
                       $from, $to, nqp::const::EDGE_EPSILON, 0);
-
-#                    note("$indent ...quant sf = $st") if $nfadeb;
+                    $to    := $state if $to < 0;
                 }
 
                 $from := self.regex_nfa($node1, $from, -1)
                   if $has_sep && $count > 0;
 
-                $from := self.regex_nfa($node0, $from, $state);
+                $from := self.regex_nfa($node0, $from, -1);
                 ++$count;
             }
 
             $state := self.addedge($from, $to, nqp::const::EDGE_EPSILON, 0);
+            $to    := $state if $to < 0;
 
             if $max == -1 {
                 my int $start := self.addstate;
                 self.addedge($from, $start, nqp::const::EDGE_EPSILON, 0);
-                $from := $start;
 
-                my $looper := self.addstate;
-                self.addedge($looper, $to,   nqp::const::EDGE_EPSILON, 0);
-                self.addedge($looper, $from, nqp::const::EDGE_EPSILON, 0);
+                my int $looper := self.addstate;
+                self.addedge($looper, $to,    nqp::const::EDGE_EPSILON, 0);
+                self.addedge($looper, $start, nqp::const::EDGE_EPSILON, 0);
 
-                $from := self.regex_nfa($node1, $from, -1)
-                  if $has_sep && $count > 0;
-
-                self.regex_nfa($node0, $from, $looper);
+                my int $atom := $has_sep
+                  ?? self.regex_nfa($node1, $start, -1)
+                  !! $start;
+                self.regex_nfa($node0, $atom, $looper);
             }
 
-            $to < 0 && $state > 0 ?? $state !! $to
-
-#            $to := $st if $to < 0 && $st > 0;
-#            note("$indent ...quant returns $to with st = $st") if $nfadeb;
-#            return dentout($to);
+            $to
         }
 
         elsif $max == -1 {

--- a/t/nqp/120-ltm-quantifier.t
+++ b/t/nqp/120-ltm-quantifier.t
@@ -1,0 +1,56 @@
+plan(16);
+
+# The declarative prefix a range quantifier contributes to longest token
+# matching must cover exactly the repetitions it allows.
+
+grammar Call {
+    regex N    { \d ** 1..3 }
+    regex FOO  { 'foo(' <N> ',' <N> ')' }
+    regex JUNK { . }
+    regex TOP  { [ <FOO> | <JUNK> ]+ }
+}
+
+my $/ := Call.parse('foo(371,776)');
+ok(?$/, 'a branch calling a range quantified subrule still parses');
+is(nqp::elems($<FOO>), 1, 'the branch calling the range quantified subrule wins once');
+is(~$<FOO>[0], 'foo(371,776)', 'that branch covers the whole input');
+is(~$<FOO>[0]<N>[0], '371', 'the first subrule call takes all three digits');
+is(~$<FOO>[0]<N>[1], '776', 'the second subrule call takes all three digits');
+
+my $m := 'a1234' ~~ / . . . . | a \d ** 1..4 /;
+is(~$m, 'a1234', 'a range quantifier ending a branch beats a shorter branch');
+
+$m := 'a1234' ~~ / . . . . | a \d ** 0..4 /;
+is(~$m, 'a1234', 'a range quantifier with a zero minimum ending a branch beats a shorter branch');
+
+$m := 'a123' ~~ / . . . | a \d ** 3 /;
+is(~$m, 'a123', 'an exact count ending a branch beats a shorter branch');
+
+$m := 'a123b' ~~ / . . . . | a \d ** 2..* b /;
+is(~$m, 'a123b', 'an open ended range in the middle of a branch beats a shorter branch');
+
+$m := 'a1,2,3' ~~ / . . . . . | a \d ** 1..4 % ',' /;
+is(~$m, 'a1,2,3', 'a separated range quantifier ending a branch beats a shorter branch');
+
+$m := 'a1,2,3' ~~ / . . . . . | a \d ** 2..* % ',' /;
+is(~$m, 'a1,2,3', 'a separated open ended range ending a branch beats a shorter branch');
+
+$m := 'a1,2,3b' ~~ / . . . . . . | a \d ** 2..* % ',' b /;
+is(~$m, 'a1,2,3b', 'a separated open ended range in the middle of a branch beats a shorter branch');
+
+$m := 'a12345' ~~ / a \d \d \d \d | a [ x | \d ** 1..3 ] { } .* /;
+is(~$m, 'a1234', 'a range quantifier ending a grouped alternative claims no more than its maximum');
+
+$m := 'a1,2,3,4,5' ~~ / a \d ',' \d ',' \d ',' \d | a [ x | \d ** 1..3 % ',' ] { } .* /;
+is(~$m, 'a1,2,3,4', 'a separated range quantifier ending a grouped alternative claims no more than its maximum');
+
+$m := 'a1,23456' ~~ / a \d ',' \d \d \d \d | a [ \d ** 1..3 ] ** 2..* % ',' { } .* /;
+is(~$m, 'a1,2345', 'a range quantifier nested in a separated open ended range beats a shorter branch');
+
+grammar Proto {
+    proto token TOP {*}
+    token TOP:sym<dots> { . . . . }
+    token TOP:sym<num>  { a \d ** 1..4 }
+}
+
+is(~Proto.parse('a1234'), 'a1234', 'a proto token candidate ending in a range quantifier beats a shorter candidate');


### PR DESCRIPTION
Previously the NFA builder for `x ** n..m` reused the caller's exit state as the landing state once the minimum count was reached, and built the next repetition from there. When the exit was a real state the remaining repetitions collapsed into self loops on it. When the exit was the fate state, which is how the last atom of a regex is built, the edges landed on the fate list instead and the saved NFA lost every repetition past the second. A subrule such as `\d ** 1..3` declared only two digits to longest token matching, so a branch calling it on a three digit number dropped out of the alternation. The open ended form `x ** n..*` in the middle of a regex also pointed its loop exit at a fresh unused state, which the optimizer remapped to zero and MoarVM rejected as an invalid edge.

This lands every repetition on a fresh state and only ever adds epsilon edges to the exit, creating the exit once when the caller did not supply one.

Fixes rakudo/rakudo#5722.