### PR TITLE
Flush the position before subrule arguments and limits blocks run

### DIFF
--- a/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
@@ -956,6 +956,7 @@ class QAST::MASTRegexCompiler {
 
         op($frame, 'set', $from_landing, %!reg<zero>);
         $frame.add-label($limitslabel);
+        op($frame, 'bindattr_i', %!reg<cur>, %!reg<curclass>, sval('$!pos'), $pos, ival(-1));
         my $minmax_mast := $!qastcomp.as_mast($minmax, :want(nqp::const::MVM_reg_obj));
         my $res_reg     := $minmax_mast.result_reg;
         op($frame, 'atpos_i', $min_reg, $res_reg, %!reg<zero>);
@@ -1249,6 +1250,9 @@ class QAST::MASTRegexCompiler {
         my $testop   := $node.negate ?? 'ge_i' !! 'lt_i';
         my $captured := 0;
 
+        op($frame, 'bindattr_i', %!reg<cur>, %!reg<curclass>, sval('$!pos'),
+            %!reg<pos>, ival(-1));
+
         # Compile all the children.
         my @arg-regs;
         my @arg-masts;
@@ -1265,8 +1269,6 @@ class QAST::MASTRegexCompiler {
         # Emit the call.
         my $p11 := %!reg<back_cur>;
         my $itmp := $!regalloc.fresh_i();
-        op($frame, 'bindattr_i', %!reg<cur>, %!reg<curclass>, sval('$!pos'),
-            %!reg<pos>, ival(-1));
         if nqp::istype($node[0][0], QAST::SVal) {
             # Method call. Shift the method name from the compiled bits
             # before doing the call.

--- a/t/nqp/034-rxcodeblock.t
+++ b/t/nqp/034-rxcodeblock.t
@@ -1,4 +1,4 @@
-plan(27);
+plan(30);
 
 grammar ABC {
     token TOP { { ok(1, 'basic code assertion'); } }
@@ -116,4 +116,33 @@ else {
     Trimmed.parse('ab', :rule<alt>);
     is( nqp::join(',', @alt), '1,0',
         'a code block sees no capture after backtracking into another alternative');
+}
+
+# A subrule argument and a quantifier limits block run in the middle of
+# the regex, so they must see the position the regex has reached.
+my @args;
+my @limits;
+grammar SeesPos {
+    token probe($p) { <?{ nqp::push(@args, ~$p); 1 }> }
+    token TOP       { a <probe($¢.pos)> b <probe($¢.pos)> c }
+    regex back      { \w+ <probe($¢.pos)> c }
+    token limits    {
+        a ** { nqp::push(@limits, ~$¢.pos); 1 }
+        b ** { nqp::push(@limits, ~$¢.pos); 1 }
+    }
+}
+SeesPos.parse('abc');
+is( nqp::join(',', @args), '1,2',
+    'a subrule argument sees the current position');
+@args := [];
+SeesPos.parse('abc', :rule<back>);
+is( nqp::join(',', @args), '3,2',
+    'a subrule argument sees the position restored by backtracking');
+if nqp::getcomp('nqp').backend.name ne 'moar' {
+    skip('a quantifier limits block sees the current position', 1);
+}
+else {
+    SeesPos.parse('ab', :rule<limits>);
+    is( nqp::join(',', @limits), '0,1',
+        'a quantifier limits block sees the current position');
 }


### PR DESCRIPTION
Previously the MoarVM regex compiler wrote the position register back to the cursor's `$!pos` only after it had compiled the arguments of a subrule call, and never before running a dynamic quantifier's limits block. Code that ran as part of either saw the cursor's stale $!pos: -3 from cursor creation, or the position of the last flush. In Raku this made `$/.pos` inside `<{ ... }>` and `** { ... }` report the wrong position unless a { } block happened to run just before.

This moves the write-back in subrule ahead of the argument compilation and adds one before the limits block in dynquant, so both see the position the regex has reached.

Fixes rakudo/rakudo#4621