### PR TITLE
Honor zerowidth and negate on regex group nodes

### DIFF
--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -175,6 +175,21 @@ class QRegex::NFA {
           || $method eq 'concat'
           || $method eq 'alt';
 
+        # A group used as an assertion ends the literal prefix and ends
+        # in a fate. A negated group gets the fate straight away, since
+        # the NFA has no negation of a group of states, and so does one
+        # the NFA has no method for. A positive group gets it after its
+        # contents, when they leave a state to attach it to.
+        if $node.subtype eq 'zerowidth'
+          && ($method eq 'alt' || $method eq 'altseq' || $method eq 'concat'
+              || $method eq 'conj' || $method eq 'conjseq') {
+            $!LITEND := 1;
+            return self.fate($node, $from, $to)
+              if $node.negate || !self.HOW.can(self, $method);
+            $from := self."$method"($node, $from, -1);
+            return $from > 0 ?? self.addedge($from, 0, nqp::const::EDGE_FATE, 0) !! 0;
+        }
+
 #        my $result :=
         self.HOW.can(self, $method)
          ?? self."$method"($node, $from, $to)

--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -513,7 +513,9 @@ class QRegex::P6Regex::Actions is HLL::Actions {
         my $qast;
         if $<assertion> {
             $qast := $<assertion>.ast;
-            $qast.subtype('zerowidth');
+            # An anchor is already zero width, and changing its subtype
+            # would turn a failing one into a check that always passes.
+            $qast.subtype('zerowidth') unless $qast.rxtype eq 'anchor';
         }
         else {
             $qast := QAST::Regex.new( :rxtype<anchor>, :subtype<pass>, :node($/) );
@@ -525,8 +527,13 @@ class QRegex::P6Regex::Actions is HLL::Actions {
         my $qast;
         if $<assertion> {
             $qast := $<assertion>.ast;
-            $qast.negate( !$qast.negate );
-            $qast.subtype('zerowidth');
+            if $qast.rxtype eq 'anchor' {
+                $qast.subtype($qast.subtype eq 'fail' ?? 'pass' !! 'fail');
+            }
+            else {
+                $qast.negate( !$qast.negate );
+                $qast.subtype('zerowidth');
+            }
         }
         else {
             $qast := QAST::Regex.new( :rxtype<anchor>, :subtype<fail>, :node($/) );
@@ -643,14 +650,26 @@ class QRegex::P6Regex::Actions is HLL::Actions {
             $curse.panic('Missing + or - between character class elements')
         }
             my $ast := $clist[$i].ast;
-            if $ast.negate || $ast.rxtype eq 'cclass' && ~$ast.node le 'Z' {
-                $ast.subtype('zerowidth');
-                $qast := QAST::Regex.new( :rxtype<concat>, :node($/), :subtype<zerowidth>, :negate(1),
-                        QAST::Regex.new( :rxtype<conj>, :subtype<zerowidth>, $ast ),
-                        $qast );
-            }
-            else {
+            if ~$clist[$i]<sign> ne '-' {
                 $qast := QAST::Regex.new( $qast, $ast, :rxtype<alt>, :node($/));
+            }
+            # An enumeration with nothing in it compiles to an anchor that
+            # fails, and subtracting nothing leaves the class alone.
+            elsif $ast.rxtype ne 'anchor' {
+                # A subtracted element compiles negated, so a zerowidth
+                # check of it ahead of the class built so far excludes its
+                # characters. A subtracted enumeration with more than one
+                # part already compiles to that check, ahead of the `.`
+                # that consumes the character.
+                my $check;
+                if $ast.rxtype eq 'concat' {
+                    $check := $ast[0];
+                }
+                else {
+                    $ast.subtype('zerowidth');
+                    $check := QAST::Regex.new( :rxtype<conj>, :subtype<zerowidth>, $ast );
+                }
+                $qast := QAST::Regex.new( :rxtype<concat>, :node($/), $check, $qast );
             }
             ++$i;
         }
@@ -790,8 +809,9 @@ class QRegex::P6Regex::Actions is HLL::Actions {
                                         :subtype($RXm ?? 'ignoremark' !! '') ))
                 if nqp::chars($str);
             $qast := ( my $num := nqp::elems(@alts) ) == 1 ?? @alts[0] !!
-                0 < $num && $<sign> eq '-' ??
-                    QAST::Regex.new( :rxtype<concat>, :node($/), :negate(1),
+                $num == 0 ?? QAST::Regex.new( :rxtype<anchor>, :subtype<fail>, :node($/) ) !!
+                $<sign> eq '-' ??
+                    QAST::Regex.new( :rxtype<concat>, :node($/),
                         QAST::Regex.new( :rxtype<conj>, :subtype<zerowidth>, |@alts ),
                         QAST::Regex.new( :rxtype<cclass>, :name<.> ) ) !!
                     QAST::Regex.new( :rxtype<alt>, |@alts );

--- a/src/QRegex/P6Regex/Optimizer.nqp
+++ b/src/QRegex/P6Regex/Optimizer.nqp
@@ -57,9 +57,11 @@ class QRegex::Optimizer {
     }
 
     method visit_concat($node) {
-        # a single-child concat can become the child itself
+        # a single-child concat can become the child itself, unless it is
+        # the concat that carries the zerowidth or negate flag
         self.visit_children($node);
-        if nqp::elems(@($node)) == 1 && $!level >= 1 {
+        if nqp::elems(@($node)) == 1 && $!level >= 1
+          && $node.subtype ne 'zerowidth' && !$node.negate {
             return $node[0];
         } elsif nqp::istype($node[0], QAST::Regex)
         && nqp::elems(@($node)) >= 2 && $!level >= 2 {

--- a/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
+++ b/src/vm/moar/QAST/QASTRegexCompilerMAST.nqp
@@ -1494,7 +1494,52 @@ class QAST::MASTRegexCompiler {
             return $mast.instructions;
         }
         my $rxtype := $node.rxtype() || 'concat';
+        # A conjunction already puts the position back itself, so it is
+        # wrapped only when negated.
+        if $node.subtype eq 'zerowidth' && is_group($rxtype)
+            && ($node.negate || $rxtype ne 'conj' && $rxtype ne 'conjseq') {
+            return self.zerowidth_group($node, $rxtype);
+        }
         self."$rxtype"($node) # expects to return an nqp::list of instructions
+    }
+
+    # Node types that combine other nodes rather than match input
+    # themselves, and whose own code ignores the negate flag. Only a
+    # conjunction among them acts on zerowidth.
+    sub is_group($rxtype) {
+        $rxtype eq 'alt' || $rxtype eq 'altseq' || $rxtype eq 'concat'
+            || $rxtype eq 'conj' || $rxtype eq 'conjseq'
+    }
+
+    # Compiles a group as an assertion: the position is put back whether
+    # the group matched or not, a negated group succeeds exactly when it
+    # did not match, and either way nothing later can backtrack into it.
+    # The mark carries the position and repetition count to restore, and
+    # gives the marks pushed by the group's contents something to be cut
+    # back to.
+    method zerowidth_group($node, $rxtype) {
+        my $frame := $!qastcomp.mast_frame;
+        my $label_index := self.rxjump();
+        my $label := @!rxjumps[$label_index];
+        self.regex_mark($label_index, %!reg<pos>, %!reg<rep>);
+        self."$rxtype"($node);
+        if $node.negate {
+            self.regex_commit($label_index);
+            op($frame, 'goto', %!reg<fail>);
+            $frame.add-label($label);
+        }
+        else {
+            my $start := $!regalloc.fresh_i();
+            my $donelabel := label();
+            self.regex_peek($label_index, $start);
+            self.regex_commit($label_index);
+            op($frame, 'set', %!reg<pos>, $start);
+            op($frame, 'goto', $donelabel);
+            $frame.add-label($label);
+            op($frame, 'goto', %!reg<fail>);
+            $frame.add-label($donelabel);
+            $!regalloc.release_register($start, nqp::const::MVM_reg_int64);
+        }
     }
 
     method uniprop($node) {

--- a/t/qregex/rx_charclass
+++ b/t/qregex/rx_charclass
@@ -98,4 +98,36 @@ abc <![d]>		abc		y	negated charclass at end of string (issue 9)
 
 <[\«]>			«		y		test for regression introduced with parrot 6.9.0
 
+## Lookarounds over character classes
+<?[\s a]> .		aa		<mob: a @ 0>	lookahead over a mixed character class does not consume
+<?[\N a]>		ab		<mob:  @ 0>		lookahead over a mixed character class is zero width
+<![\s a]> .		bb		<mob: b @ 0>	negated lookahead over a mixed character class matches when neither part does
+<![\s a]> .		aa		n				negated lookahead over a mixed character class fails on the character part
+<![\s a]> .		\x0020a	n				negated lookahead over a mixed character class fails on the backslash part
+<![\s a]>		''		y				negated lookahead over a mixed character class matches at the end of the string
+<![a \s]> .		ab		<mob: b @ 1>	negated lookahead over a mixed character class whose first part matches moves on
+<?[a] - [b]> .	aa		<mob: a @ 0>	lookahead over a character class subtraction does not consume
+<![a] - [b]> .	bb		<mob: b @ 0>	negated lookahead over a character class subtraction matches a subtracted character
+<![a] - [b]> .	aa		n				negated lookahead over a character class subtraction fails on a remaining character
+<?[a] - [\s b]> .	aa		<mob: a @ 0>	lookahead over a subtraction of a mixed character class does not consume
+<![\w] - [\d _]> .	\x0020	<mob:   @ 0>	negated lookahead over a subtraction of a mixed character class matches an excluded character
+<?[a 1] - digit> .	aa		<mob: a @ 0>	lookahead over a subtraction of a named character class does not consume
+<?-[\s a]> .	bb		<mob: b @ 0>	lookahead over a negated mixed character class does not consume
+<!-[\s a]> .	aa		<mob: a @ 0>	negated lookahead over a negated mixed character class matches an excluded character
+[<![\s a]> .]+	xyz a	<mob: xyz @ 0>	negated lookahead over a mixed character class inside a quantifier
+[<![\s a]> .] ** 2	xyz		<mob: xy @ 0>	negated lookahead over a mixed character class inside a bounded quantifier
+[<?[\s a]> (.)]+ a	aaa		<mob[0][1]: a @ 1>	quantified lookahead group backtracks by whole iterations
+[<?[\s a]> b | a]	ab		<mob: a @ 0>	failing atom after a lookahead group backtracks into the next alternative
+[<?[\s a]> b || a]	ab		<mob: a @ 0>	failing atom after a lookahead group backtracks into the next sequential alternative
+a [<![\s a]> . | a]	aab		<mob: aa @ 0>	failing negated lookahead group backtracks into the next alternative
+$<x>=[<?[\s a]> .] | $<y>=[..]	ab	<mob<y>: ab @ 0>	longest token matching counts a lookahead group as one character
+(<?[\s a]>) (.)	aa		<mob[0]:  @ 0>	capture around a lookahead group is empty
+<[a] + [\S]>	b		y				plus sign keeps a negated backslash sequence as a union
+<[a] - []>		a		y				subtracting an empty enumeration leaves the class alone
+<?[a] - []> a	a		y				lookahead over a class subtracting an empty enumeration leaves the class alone
+<![a] - []> .	bb		<mob: b @ 0>	negated lookahead over a class subtracting an empty enumeration matches an excluded character
+<?[]>			a		n				lookahead over an empty enumeration never matches
+<![]> a			a		y				negated lookahead over an empty enumeration always matches
+$<x>=[<?[a] - [b]> . 'b'] | $<y>=[. 'bb']	ab	<mob<x>: ab @ 0>	longest token matching falls through to a lookahead over a subtraction
+
 ## vim: noexpandtab tabstop=4 shiftwidth=4


### PR DESCRIPTION
Previously the MoarVM regex compiler only acted on the `zerowidth` and `negate` flags of leaf nodes. A lookaround over a character class that compiles to an `alt` or `concat` (e.g. `<?[\s a]>` or `<![a] - [b]>`) had the flags set on that group node, so its parts still consumed a character and a negated one was not inverted at all.

```
$ nqp -e 'say("aa" ~~ /<?[\s a]> ./)'
aa
$ nqp -e 'say("bb" ~~ /<![\s a]> ./)'

```

This compiles a zerowidth group as an assertion, i.e. the position is put back once it matched, a negated group succeeds exactly when it did not match, and its marks are cut so nothing later backtracks into it. The NFA ends the declarative prefix at such a group the same way it does for `<!before ...>`.

The actions were also using those flags as markers on `concat` nodes, which the compiler would now read as a negated assertion. As such the first commit decides subtraction by the sign in front of the element instead, which incidentally fixes `<[a] + [\S]>` subtracting instead of adding, and gives an empty enumeration the same failing anchor RakuAST uses so `<?[]>` never matches.

Fixes rakudo/rakudo#4512
