### PR TITLE
Fix ignoremark and escape handling in character classes

### DIFF
--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -315,7 +315,8 @@ class QRegex::NFA {
 #        note("$indent enumcharlist $from -> $to") if $nfadeb;
 
         my $charlist := nqp::atpos($node, 0);
-        if $node.subtype eq 'zerowidth' {
+        my str $subtype := $node.subtype;
+        if $subtype eq 'zerowidth' {
             $from := self.addedge(
               $from, -1, nqp::const::EDGE_CHARLIST + ?$node.negate, $charlist
             );
@@ -323,6 +324,23 @@ class QRegex::NFA {
 #            dentout(self.addedge($from, 0, nqp::const::EDGE_FATE, 0));
 
             self.addedge($from, 0, nqp::const::EDGE_FATE, 0)
+        }
+
+        # A charlist edge compares whole graphemes, so an ignoremark list gets
+        # one base character edge per entry. A negated list keeps the charlist
+        # edge, which only ever lets more branches through.
+        elsif !$node.negate && nqp::chars($charlist)
+          && ($subtype eq 'ignoremark' || $subtype eq 'ignorecase+ignoremark') {
+            my int $n := nqp::chars($charlist);
+            my int $i;
+            while $i < $n {
+                $to := self.addedge(
+                  $from, $to, nqp::const::EDGE_CODEPOINT_M,
+                  nqp::ordbaseat($charlist, $i)
+                );
+                ++$i;
+            }
+            $to
         }
 
         else {

--- a/src/QRegex/P6Regex/Actions.nqp
+++ b/src/QRegex/P6Regex/Actions.nqp
@@ -711,6 +711,47 @@ class QRegex::P6Regex::Actions is HLL::Actions {
             my $RXi := %*RX<i>;
             my $RXm := %*RX<m>;
             my $RXim := $RXi && $RXm;
+            sub enumcharlist(str $chars) {
+                QAST::Regex.new( $chars, :rxtype<enumcharlist>, :node($/), :negate( $<sign> eq '-' ),
+                                 :subtype($RXm ?? 'ignoremark' !! '') )
+            }
+            # Fold after assembly since adjacent entries can form one grapheme.
+            # A folded entry that would form one with the entry before it
+            # becomes a list of its own. A case form that is not a single
+            # character cannot be an entry and is left out.
+            sub fold_entries(str $entries) {
+                my str $folded := '';
+                sub add_entry(str $c) {
+                    my str $joined := $folded ~ $c;
+                    if nqp::index($folded, $c) >= 0 {
+                    }
+                    elsif nqp::chars($joined) == nqp::chars($folded) + 1 {
+                        $folded := $joined;
+                    }
+                    else {
+                        @alts.push(enumcharlist($c));
+                    }
+                }
+                sub add_case_form(str $form, str $c) {
+                    add_entry($form) if nqp::chars($form) == 1 && $form ne $c;
+                }
+                my int $n := nqp::chars($entries);
+                my int $i;
+                while $i < $n {
+                    my str $c := $RXm
+                        ?? nqp::chr(nqp::ordbaseat($entries, $i))
+                        !! nqp::substr($entries, $i, 1);
+                    add_entry($c);
+                    if $RXi {
+                        add_case_form(nqp::fc($c), $c);
+                        add_case_form(nqp::uc($c), $c);
+                        add_case_form(nqp::lc($c), $c);
+                        add_case_form(nqp::tc($c), $c);
+                    }
+                    ++$i;
+                }
+                $folded
+            }
             for $<charspec> {
                 if $_[1] {
                     my $node;
@@ -790,24 +831,12 @@ class QRegex::P6Regex::Actions is HLL::Actions {
                         @alts.push($bs);
                     }
                 }
-                elsif $RXim {
-                    my $c := nqp::chr(nqp::ordbaseat(~$_[0], 0));
-                    $str := $str ~ nqp::fc($c) ~ nqp::uc($c);
-                }
-                elsif $RXi {
-                    my $c := ~$_[0];
-                    $str := $str ~ nqp::fc($c) ~ nqp::uc($c);
-                }
-                elsif $RXm {
-                    $str := $str ~ nqp::chr(nqp::ordbaseat(~$_[0], 0));
-                }
                 else {
                     $str := $str ~ ~$_[0];
                 }
             }
-            @alts.push(QAST::Regex.new( $str, :rxtype<enumcharlist>, :node($/), :negate( $<sign> eq '-' ),
-                                        :subtype($RXm ?? 'ignoremark' !! '') ))
-                if nqp::chars($str);
+            $str := fold_entries($str) if $RXi || $RXm;
+            @alts.push(enumcharlist($str)) if nqp::chars($str);
             $qast := ( my $num := nqp::elems(@alts) ) == 1 ?? @alts[0] !!
                 $num == 0 ?? QAST::Regex.new( :rxtype<anchor>, :subtype<fail>, :node($/) ) !!
                 $<sign> eq '-' ??

--- a/t/qregex/rx_charclass
+++ b/t/qregex/rx_charclass
@@ -130,4 +130,8 @@ $<x>=[<?[\s a]> .] | $<y>=[..]	ab	<mob<y>: ab @ 0>	longest token matching counts
 <![]> a			a		y				negated lookahead over an empty enumeration always matches
 $<x>=[<?[a] - [b]> . 'b'] | $<y>=[. 'bb']	ab	<mob<x>: ab @ 0>	longest token matching falls through to a lookahead over a subtraction
 
+# todo 2 :jvm<combining characters need NFG>
+<[b\x[308]]>	b\x0308	y	base character and adjacent combining escape form one entry
+<[b\x[308]]>	b	n	base character that forms one entry with a combining escape is not an entry on its own
+
 ## vim: noexpandtab tabstop=4 shiftwidth=4

--- a/t/qregex/rx_modifiers
+++ b/t/qregex/rx_modifiers
@@ -1,6 +1,15 @@
 # todo :jvm<ignorecase+ignoremark doesn't work on jvm>
 :i:m ﬆ			st	y	ignorecase ignoremark with ligature ﬆ (:i:m)
 :i:m "All hell is breaking loose"			"All is fine, I am sure of it" 	n	RT128875 :i:m combined matches whole string when a single character match is found
+# todo 7 :jvm<ignoremark charclass needs NFG>
+# todo 7 :js<ignoremark charclass needs NFG>
+:m <[a \n]>	a\x0300	y	ignoremark charclass with newline escape matches marked character
+:m <[a \n]>	x	n	ignoremark charclass with newline escape rejects other character
+:m [\n | <[a]>]	a\x0300	y	ignoremark charclass after alternation matches marked character
+:m [<[a]> | \n]	a\x0300	y	ignoremark charclass before alternation matches marked character
+:m [\n | <[b a]>]	a\x0300	y	ignoremark charclass in alternation matches on its second entry
+:m [\n | <[b a]>]	c\x0300	n	ignoremark charclass in alternation rejects marked character not in list
+:m <-[a \n]>	a\x0300	n	negated ignoremark charclass with newline escape rejects marked character
 ##  modifiers
 # todo 6 :jvm<ligature problem>
 :i ﬆ			st	y	ignorecase with ligature ﬆ (:i)

--- a/t/qregex/rx_modifiers
+++ b/t/qregex/rx_modifiers
@@ -2,7 +2,6 @@
 :i:m ﬆ			st	y	ignorecase ignoremark with ligature ﬆ (:i:m)
 :i:m "All hell is breaking loose"			"All is fine, I am sure of it" 	n	RT128875 :i:m combined matches whole string when a single character match is found
 # todo 7 :jvm<ignoremark charclass needs NFG>
-# todo 7 :js<ignoremark charclass needs NFG>
 :m <[a \n]>	a\x0300	y	ignoremark charclass with newline escape matches marked character
 :m <[a \n]>	x	n	ignoremark charclass with newline escape rejects other character
 :m [\n | <[a]>]	a\x0300	y	ignoremark charclass after alternation matches marked character
@@ -10,6 +9,32 @@
 :m [\n | <[b a]>]	a\x0300	y	ignoremark charclass in alternation matches on its second entry
 :m [\n | <[b a]>]	c\x0300	n	ignoremark charclass in alternation rejects marked character not in list
 :m <-[a \n]>	a\x0300	n	negated ignoremark charclass with newline escape rejects marked character
+# todo 6 :jvm<ignoremark charclass needs NFG>
+:m <[\x[E0]]>	a	y	hex escape in ignoremark charclass ignores its mark
+:m <[a \x[300]]>	a\x0300	y	ignoremark charclass entry formed by a base character and combining escape matches marked character
+:m <[\x[300]]>	\x0300	y	ignoremark charclass that is only a combining escape matches that mark
+:m <-[a \x[300]]>	a\x0300	n	negated ignoremark charclass entry formed by a base character and combining escape rejects marked character
+:m <-[a \x[300]]>	b\x0300	y	negated ignoremark charclass entry formed by a base character and combining escape accepts other marked character
+:i:m [\n | <[\x[61]]>]	A\x0300	y	hex escape in ignorecase ignoremark charclass in alternation ignores case and mark
+:i <[\x[4D]]>	m	y	hex escape in ignorecase charclass ignores case
+:i <[\c[LATIN CAPITAL LETTER M]]>	m	y	named escape in ignorecase charclass ignores case
+:i <[\x[DF]]>	\x00DF	y	escape that folds to two characters still matches itself in ignorecase charclass
+:i <[\x[DF]]>	s	n	escape that folds to two characters does not match part of the fold
+:i <[\x[300]]>	\x0300	y	lone combining escape in ignorecase charclass matches itself
+:i <[\c[LATIN SMALL LIGATURE FF]]>	f	n	ligature escape in ignorecase charclass does not match part of the fold
+:i <[ß]>	\x00DF	y	plain character that folds to two characters still matches itself in ignorecase charclass
+:i <[ﬀ]>	\xFB00	y	plain ligature still matches itself in ignorecase charclass
+:i <-[\x[4D]]>	m	n	negated ignorecase charclass with hex escape rejects the other case
+:i <-[\x[4D]]>	n	y	negated ignorecase charclass with hex escape accepts other characters
+:i <[ǆ]>	ǅ	y	ignorecase charclass matches the titlecase form of its entry
+# todo 7 :jvm<combining characters need NFG>
+:i:m <[\x[C0]]>	a	y	hex escape with a mark in ignorecase ignoremark charclass matches the bare base character
+:m [\n | <-[a]>]	b\x0300	y	negated ignoremark charclass in alternation accepts other marked character
+:m [\n | <-[a]>]	a\x0300	n	negated ignoremark charclass in alternation rejects marked character
+:i <[a \x[308]]>	\x00E4	y	ignorecase charclass entry formed by a base character and combining escape matches itself
+:i <[a \x[308]]>	a	n	ignorecase charclass entry formed by a base character and combining escape does not match the bare base character
+:m <[\x[D]\x[A] \x[A]]>	\n	y	folded entries that would form one grapheme stay separate entries
+:m <[\x[D]\x[A] \x[A]]>	\r	y	folded carriage return newline entry matches a carriage return
 ##  modifiers
 # todo 6 :jvm<ligature problem>
 :i ﬆ			st	y	ignorecase with ligature ﬆ (:i)


### PR DESCRIPTION
Previously `"a\x[300]" ~~ / :ignoremark <[ a \n ]> /` returned Nil while `<[ a b ]>` matched. Any class escape such as `\n` turns the class into an alternation, and the LTM NFA gave the ignoremark character list a charlist edge that compares whole graphemes, so the branch was ruled out before the mark insensitive runtime check ever ran. The first commit gives such a list one base character edge per entry, the same edge an ignoremark literal already gets.

While looking at this it turned out the class builder folded plain characters for `:i` and `:m` one at a time before appending them, and never folded escaped characters at all. As such `<[ \x[E0] ]>` under `:m` did not match `a`, and an entry that adjacent characters form under NFG, e.g. the `à` in `<[ a \x[300] ]>`, was never reduced to its base. The case folding also replaced a character by `fc ~ uc` even when a form was not a single character, so `<[ ß ]>` under `:i` matched `s` but not `ß`. The second commit assembles the entries first and then folds each grapheme of the result, keeping the character itself and only adding case forms that are a single character.

Fixes rakudo/rakudo#2962
