### PR TITLE
Stop the declarative prefix at a sequential alternation

### DIFF
--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -689,7 +689,7 @@ class QRegex::NFA {
             # Land each repetition on its own state. Landing on $to would
             # start the next repetition from the caller's exit, and for the
             # last atom of a regex that exit is state 0, the fate list.
-            while $count < $max || $count < $min {
+            while ($count < $max || $count < $min) && $from > 0 {
                 if $count >= $min {
                     $state := self.addedge(
                       $from, $to, nqp::const::EDGE_EPSILON, 0);
@@ -702,6 +702,9 @@ class QRegex::NFA {
                 $from := self.regex_nfa($node0, $from, -1);
                 ++$count;
             }
+
+            # Only the paths that skipped this repetition remain.
+            return $to > 0 ?? $to !! 0 unless $from > 0;
 
             $state := self.addedge($from, $to, nqp::const::EDGE_EPSILON, 0);
             $to    := $state if $to < 0;

--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -241,26 +241,16 @@ class QRegex::NFA {
         $to
     }
 
+    # Only the first branch is visible to longest token matching. The
+    # rest of the group and whatever follows it may match anything, so
+    # the prefix also ends here with nothing matched.
     method altseq($node, int $from, int $to) {
         if nqp::elems($node) {
-
-#            my $indent := dentin();
-
-            my int $state := self.regex_nfa(nqp::atpos($node,0), $from, $to);
-            $to := $state if $to < 0 && $state > 0;
-
-            $state := self.addedge($from, $to, nqp::const::EDGE_EPSILON, 0);
-            $to < 0 && $state > 0 ?? $state !! $to
-
-#            $to := $st if $to < 0 && $st > 0;
-#            note("$indent ...altseq returns $to") if $nfadeb;
-#            dentout($to);
-#            $to;
+            my int $state := self.regex_nfa(nqp::atpos($node,0), $from, -1);
+            self.fate($node, $state, 0) if $state > 0;
         }
-
-        else {
-            self.fate($node, $from, $to)
-        }
+        self.fate($node, $from, 0);
+        0
     }
 
     method anchor($node, int $from, int $to) {

--- a/t/nqp/121-ltm-sequential-alternation.t
+++ b/t/nqp/121-ltm-sequential-alternation.t
@@ -1,0 +1,68 @@
+plan(19);
+
+# Only the first branch of a sequential alternation takes part in longest
+# token matching. The rest of the group and what follows it are hidden.
+
+my $m := 'yz' ~~ / w | [ x || y ] z /;
+is(~$m, 'yz', 'a branch whose sequential alternation starts with a non matching option is still tried');
+
+$m := 'yz' ~~ / [ x || y ] z | w /;
+is(~$m, 'yz', 'the same branch is still tried when it comes first');
+
+$m := 'xz' ~~ / w | [ x || y ] z /;
+is(~$m, 'xz', 'the first option of the sequential alternation still matches');
+
+$m := 'wz' ~~ / w | [ x || y ] z /;
+is(~$m, 'w', 'the other branch still matches');
+
+$m := 'abc' ~~ / ab | [ a || ab ] c /;
+is(~$m, 'ab', 'only the first option of the sequential alternation counts towards the declarative prefix');
+
+$m := 'abc' ~~ / a | [ ab || a ] c /;
+is(~$m, 'abc', 'a longer first option beats a shorter branch');
+
+$m := 'yz' ~~ / w | <?before x || y> yz /;
+is(~$m, 'yz', 'a sequential alternation inside a lookahead does not hide the branch');
+
+$m := 'xzz' ~~ / xz | [ x || y ] zz /;
+is(~$m, 'xz', 'what follows the sequential alternation does not extend the declarative prefix');
+
+$m := 'xzz' ~~ / xz | [ x || y ] { } zz /;
+is(~$m, 'xz', 'a code block after the sequential alternation still ends the declarative prefix');
+
+$m := 'xxz' ~~ / xx | [ x || q ] ** 2 z /;
+is(~$m, 'xx', 'a quantified sequential alternation does not extend the declarative prefix');
+
+$m := 'yyz' ~~ / w | [ x || y ] ** 2 z /;
+is(~$m, 'yyz', 'a quantified sequential alternation does not hide the branch');
+
+$m := 'yz' ~~ / w | [ x || y ]? z /;
+is(~$m, 'yz', 'an optional sequential alternation does not hide the branch');
+
+$m := 'yyz' ~~ / w | [ x || y ]+ z /;
+is(~$m, 'yyz', 'a repeated sequential alternation does not hide the branch');
+
+$m := 'yz' ~~ / w | ( x || y ) z /;
+is(~$m, 'yz', 'a capturing sequential alternation does not hide the branch');
+
+$m := 'yz' ~~ / w | [ x || q || y ] z /;
+is(~$m, 'yz', 'a sequential alternation with three options does not hide the branch');
+
+$m := 'yz' ~~ / w | [ q || [ x | y ] ] z /;
+is(~$m, 'yz', 'a longest token alternation nested in a sequential alternation does not hide the branch');
+
+grammar Call {
+    token opt { x || y }
+    token TOP { w | <opt> z }
+}
+
+is(~Call.parse('yz'), 'yz', 'a called subrule starting with a sequential alternation does not hide the branch');
+
+grammar Proto {
+    proto token TOP {*}
+    token TOP:sym<w>  { w }
+    token TOP:sym<xy> { [ x || y ] z }
+}
+
+is(~Proto.parse('yz'), 'yz', 'a proto token candidate starting with a sequential alternation is still tried');
+is(~Proto.parse('xz'), 'xz', 'the first option of that candidate still matches');


### PR DESCRIPTION
Previous the NFA for `||` built its first branch plus an empty path and then let the enclosing concat keep going, so the declarative prefix of `[ x || y ] z` was effectively `x? z`. A `|` branch containing that group never got a fate on input like `yz` and was never tried:

```
say q[yz] ~~ token { w | [ x | y ] z }   # ｢yz｣
say q[yz] ~~ token { w | [ x || y ] z }  # Nil
```

S05 says `||` terminates the longest token while its first branch stays visible. This makes `altseq` emit a fate after the first branch and a fate from its entry state, and return nothing to continue from, so nothing after the group extends the prefix. The second commit guards the counted `**` loop in `quant` so a repetition that ends the prefix no longer pushes edges onto the fate list, which `[ x || y ] ** 2` now does.

This shifts one tie in the Raku grammar: `.&::("foo")` now parses as `dotty:sym<.>` with a `&::("foo")` variable rather than `dotty:sym<.&>` with a longname, because the old NFA only reached one character further by continuing past a `<.ws>` fate.

Fixes rakudo/rakudo#2697