### PR TITLE
End the declarative prefix at a frugal quantifier

### DIFF
--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -125,12 +125,17 @@ class QRegex::NFA {
         $to      := self.addstate if $to < 0;
         my @this := nqp::atpos(@!states, $from);
 
+        # A fate that repeats an earlier one becomes an epsilon edge to
+        # the state already carrying it. It still ends the prefix, so
+        # the caller gets no state to keep building from.
+        my int $ended;
         if $action == nqp::const::EDGE_FATE {
             my $known_value := nqp::atpos($!known, $value);
             if $known_value {
                 if nqp::not_i($to) || $to == $known_value {
                     $action := nqp::const::EDGE_EPSILON;
                     $to     := $known_value;
+                    $ended  := 1;
                 }
             }
             elsif nqp::elems(@this) == 0 {
@@ -143,7 +148,8 @@ class QRegex::NFA {
 
         nqp::push(@this, $action);
         nqp::push(@this, $value);
-        nqp::push(@this, $to)  # push returns value being pushed
+        nqp::push(@this, $to);
+        $ended ?? 0 !! $to
     }
 
     method states() { @!states }

--- a/src/QRegex/NFA.nqp
+++ b/src/QRegex/NFA.nqp
@@ -680,6 +680,11 @@ class QRegex::NFA {
 
 #        my $indent := dentin();
 
+        # A frugal quantifier ends the declarative prefix. The atom it
+        # quantifies matches as little as it can, so neither it nor
+        # anything after it belongs to the longest token.
+        return self.fate($node, $from, $to) if $node.backtrack eq 'f';
+
         my int $min := $node.min // 0;
         my int $max := $node.max // -1; # -1 means Inf
         my $node0   := nqp::atpos($node, 0);

--- a/t/nqp/122-ltm-shared-fate.t
+++ b/t/nqp/122-ltm-shared-fate.t
@@ -1,0 +1,24 @@
+plan(5);
+
+# A fate that repeats an earlier one in the same NFA still ends the
+# declarative prefix. Nothing after it belongs to the longest token.
+
+my $m := 'xzzz' ~~ / <?before 'x' {}> . . . | 'x' . /;
+is(~$m, 'xz', 'atoms after a lookahead ended by a code block do not extend the prefix');
+
+$m := 'acc' ~~ / [ 'a' {} | 'b' {} ] 'c' 'c' | 'a' . /;
+is(~$m, 'ac', 'atoms after a group whose branches end in code blocks do not extend the prefix');
+
+$m := 'xzzz' ~~ / 'x' <?before {}> . . | 'x' . /;
+is(~$m, 'xz', 'atoms after a lookahead whose body is only a code block do not extend the prefix');
+
+$m := 'xzzz' ~~ / <?before <.ws> 'x'> . . . | 'x' . /;
+is(~$m, 'xz', 'atoms after a lookahead whose body starts with ws do not extend the prefix');
+
+grammar Proto {
+    proto token TOP {*}
+    token TOP:sym<lookahead> { <?before 'x' {}> . . . }
+    token TOP:sym<x>         { 'x' . }
+}
+
+is(~Proto.parse('xzzz'), 'xz', 'atoms after a lookahead ended by a code block do not extend a proto token candidate');

--- a/t/nqp/123-ltm-frugal-quantifier.t
+++ b/t/nqp/123-ltm-frugal-quantifier.t
@@ -1,0 +1,58 @@
+plan(15);
+
+# A frugal quantifier ends the declarative prefix a branch contributes to
+# longest token matching. What comes before it still counts.
+
+my $m := 'aaaaaaaaa' ~~ / | a+? | a+ /;
+is(~$m, 'aaaaaaaaa', 'a greedy branch beats a frugal branch declared before it');
+
+$m := 'aaaaaaaaa' ~~ / | a+ | a+? /;
+is(~$m, 'aaaaaaaaa', 'a greedy branch beats a frugal branch declared after it');
+
+$m := 'aab' ~~ / \w a?? | \w a /;
+is(~$m, 'aa', 'a frugal optional branch loses to a longer branch');
+
+$m := 'a12' ~~ / a \d **? 1..2 | a \d \d /;
+is(~$m, 'a12', 'a frugal range quantifier ends the prefix');
+
+$m := 'a1,2,3' ~~ / . . . . . | a \d+? % ',' /;
+is(~$m, 'a1,2,', 'a frugal separated quantifier ends the prefix');
+
+$m := 'xabbb' ~~ / x | xab+? /;
+is(~$m, 'xab', 'the atoms before a frugal quantifier still form the prefix');
+
+$m := 'aaab' ~~ / a+?b | . . . /;
+is(~$m, 'aaa', 'the atoms after a frugal quantifier do not extend the prefix');
+
+$m := 'abbb' ~~ / a [ b+? | bb ] /;
+is(~$m, 'abb', 'a frugal branch nested in a group loses to a longer branch');
+
+$m := 'abcbc' ~~ / . . . . | a [ b | c ]+? /;
+is(~$m, 'abcb', 'a frugal quantifier on a group ends the prefix');
+
+$m := 'aab' ~~ / .*?b | a /;
+is(~$m, 'a', 'a branch that starts with a frugal quantifier declares an empty prefix');
+
+$m := '(ab)/c' ~~ / '(' | <?before .+? '/'> . . . . . . /;
+is(~$m, '(', 'a frugal quantifier inside a lookahead ends the prefix');
+
+$m := '(ab)/c' ~~ / '(' | <?before .+ '/'> . . . . . . /;
+is(~$m, '(ab)/c', 'a greedy quantifier inside a lookahead keeps declaring the prefix');
+
+grammar Proto {
+    proto token TOP {*}
+    token TOP:sym<frugal> { a+? }
+    token TOP:sym<greedy> { a+ }
+}
+
+is(~Proto.parse('aaaa'), 'aaaa', 'a greedy proto token candidate beats a frugal candidate');
+
+grammar Call {
+    token F   { a+? }
+    token G   { a+ }
+    token TOP { <F> | <G> }
+}
+
+$m := Call.parse('aaaa');
+is(~$m, 'aaaa', 'a branch calling a greedy subrule beats a branch calling a frugal subrule');
+ok(!$m<F> && ?$m<G>, 'the greedy subrule is the one that ran');


### PR DESCRIPTION
S05 lists a frugal quantifier among the constructs that end the longest token, but the NFA builder treated `a+?` exactly like `a+`. Two branches that differ only in greediness tied, the tie went to the first one declared, and it then matched frugally:

```
$ raku -e 'say "aaaaaaaaa" ~~ m/ | a+? | a+ /'
｢a｣
```

Now the builder emits a fate at a frugal quantifier, so atoms before it still count toward the prefix and nothing from the quantified atom onward does. There is no exemption for lookaheads: S05 counts a lookahead's pattern toward the token only as far as it is pure, so `<?before .+? x>` ends the prefix the same way. Grammars that relied on that idiom can switch to `.+`, which behaves the same inside a lookahead on every release.

While testing that I found `addedge` turning a repeated fate into an epsilon edge and then returning the target state as if the builder could keep going from it. Everything after `<?before x {}>`, or after a group whose branches all end in a terminator, was still being attached to the prefix. The first commit fixes that on its own.

rakudo/rakudo#1924
